### PR TITLE
Feat(securedelete builder) : New Public Delete API & Enhanced Legacy Error Handling

### DIFF
--- a/src/api/delete/builder.rs
+++ b/src/api/delete/builder.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 #[cfg(not(feature = "error-stack"))]
 use crate::{Error, Result};
-
+#[cfg(feature = "error-stack")]
+use error_stack::ResultExt;
+#[cfg(feature = "error-stack")]
+use crate::{Result,Error};
 
 use super::request::{DeleteMethod, DeleteRequest};
 
@@ -76,6 +79,73 @@ mod tests {
 
 	#[test]
 	fn build_succeeds_when_all_parameters_are_present() {
+		let result = DeleteRequestBuilder::new()
+			.path(PathBuf::from("/tmp/file.txt"))
+			.method(DeleteMethod::BuiltIn(Method::default()))
+			.build();
+
+		assert!(result.is_ok());
+	}
+}
+
+#[cfg(feature = "error-stack")]
+impl DeleteRequestBuilder {
+	pub fn build(self) -> Result<DeleteRequest> {
+		let path = self.path.ok_or(Error::MissingParameter("path"))?;
+		let method = self.method.ok_or(Error::MissingParameter("method"))?;
+		Ok(DeleteRequest { path, method })
+	}
+}
+
+#[cfg(all(test, feature = "error-stack"))]
+mod tests {
+	use super::*;
+	use crate::Method;
+	use crate::api::delete::request::DeleteMethod ;
+	use error_stack::Frame;
+	use std::path::PathBuf;
+
+	#[test]
+	fn build_fails_when_path_is_missing() {
+
+		let result = DeleteRequestBuilder::new()
+			.method(DeleteMethod::BuiltIn(Method::default()))
+			.build();
+
+		assert!(result.is_err());
+
+		let err = result.unwrap_err();
+
+		assert!(err.frames().any(|frame| {
+			frame
+				.downcast_ref::<Error>()
+				.is_some_and(|e| matches!(e, Error::MissingParameter("path")))
+		}));
+	}
+
+	#[test]
+	fn build_fails_when_method_is_missing() {
+		use std::path::PathBuf;
+
+		let result = DeleteRequestBuilder::new()
+			.path(PathBuf::from("/tmp/file.txt"))
+			.build();
+
+		assert!(result.is_err());
+
+		let err = result.unwrap_err();
+
+		assert!(err.frames().any(|frame| {
+			frame
+				.downcast_ref::<Error>()
+				.is_some_and(|e| matches!(e, Error::MissingParameter("method")))
+		}));
+	}
+
+	#[test]
+	fn build_succeeds_when_all_parameters_are_present() {
+		use std::path::PathBuf;
+
 		let result = DeleteRequestBuilder::new()
 			.path(PathBuf::from("/tmp/file.txt"))
 			.method(DeleteMethod::BuiltIn(Method::default()))

--- a/src/api/delete/builder.rs
+++ b/src/api/delete/builder.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(not(feature = "error-stack"))]
+use crate::{Error, Result};
+
+
+use super::request::{DeleteMethod, DeleteRequest};
+
+#[derive(Debug, Default)]
+#[cfg_attr(test,derive(PartialEq))]
+pub struct DeleteRequestBuilder {
+	path: Option<PathBuf>,
+	method: Option<DeleteMethod>,
+}
+
+impl DeleteRequestBuilder {
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	pub fn path<P: AsRef<Path>>(mut self, path: P) -> Self {
+		self.path = Some(path.as_ref().to_path_buf());
+		self
+	}
+
+	pub fn method(mut self, method: DeleteMethod) -> Self {
+		self.method = Some(method);
+		self
+	}
+
+}
+
+#[cfg(not(feature = "error-stack"))]
+impl DeleteRequestBuilder {
+	pub fn build(self) -> Result<DeleteRequest> {
+		let path = self.path.ok_or(
+			Error::MissingParameter("path")
+		)?;
+
+		let method = self.method.ok_or(
+			Error::MissingParameter("method")
+		)?;
+
+		Ok(DeleteRequest { path, method })
+	}
+}
+
+#[cfg(all(test, not(feature = "error-stack")))]
+mod tests {
+	use super::*;
+	use crate::{Error, Method};
+	use pretty_assertions::assert_eq;
+	use std::path::PathBuf;
+
+	#[test]
+	fn build_fails_when_path_is_missing() {
+		let result = DeleteRequestBuilder::new()
+			.method(DeleteMethod::BuiltIn(Method::default()))
+			.build();
+
+		let err = result.expect_err("builder should fail without path");
+
+		assert_eq!(err, Error::MissingParameter("path"));
+	}
+
+	#[test]
+	fn build_fails_when_method_is_missing() {
+		let result = DeleteRequestBuilder::new()
+			.path(PathBuf::from("/tmp/file.txt"))
+			.build();
+
+		let err = result.expect_err("builder should fail without method");
+
+		assert_eq!(err, Error::MissingParameter("method"));
+	}
+
+	#[test]
+	fn build_succeeds_when_all_parameters_are_present() {
+		let result = DeleteRequestBuilder::new()
+			.path(PathBuf::from("/tmp/file.txt"))
+			.method(DeleteMethod::BuiltIn(Method::default()))
+			.build();
+
+		assert!(result.is_ok());
+	}
+}

--- a/src/api/delete/builder.rs
+++ b/src/api/delete/builder.rs
@@ -3,154 +3,148 @@ use std::path::{Path, PathBuf};
 #[cfg(not(feature = "error-stack"))]
 use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
-use error_stack::ResultExt;
+use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
-use crate::{Result,Error};
+use error_stack::ResultExt;
 
 use super::request::{DeleteMethod, DeleteRequest};
 
 #[derive(Debug, Default)]
-#[cfg_attr(test,derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct DeleteRequestBuilder {
-	path: Option<PathBuf>,
-	method: Option<DeleteMethod>,
+    path: Option<PathBuf>,
+    method: Option<DeleteMethod>,
 }
 
 impl DeleteRequestBuilder {
-	pub fn new() -> Self {
-		Self::default()
-	}
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-	pub fn path<P: AsRef<Path>>(mut self, path: P) -> Self {
-		self.path = Some(path.as_ref().to_path_buf());
-		self
-	}
+    pub fn path<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.path = Some(path.as_ref().to_path_buf());
+        self
+    }
 
-	pub fn method(mut self, method: DeleteMethod) -> Self {
-		self.method = Some(method);
-		self
-	}
-
+    pub fn method(mut self, method: DeleteMethod) -> Self {
+        self.method = Some(method);
+        self
+    }
 }
 
 #[cfg(not(feature = "error-stack"))]
 impl DeleteRequestBuilder {
-	pub fn build(self) -> Result<DeleteRequest> {
-		let path = self.path.ok_or(
-			Error::MissingParameter("path")
-		)?;
+    pub fn build(self) -> Result<DeleteRequest> {
+        let path = self.path.ok_or(Error::MissingParameter("path"))?;
 
-		let method = self.method.ok_or(
-			Error::MissingParameter("method")
-		)?;
+        let method = self.method.ok_or(Error::MissingParameter("method"))?;
 
-		Ok(DeleteRequest { path, method })
-	}
+        Ok(DeleteRequest { path, method })
+    }
 }
 
 #[cfg(all(test, not(feature = "error-stack")))]
 mod tests {
-	use super::*;
-	use crate::{Error, Method};
-	use pretty_assertions::assert_eq;
-	use std::path::PathBuf;
+    use super::*;
+    use crate::{Error, Method};
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
 
-	#[test]
-	fn build_fails_when_path_is_missing() {
-		let result = DeleteRequestBuilder::new()
-			.method(DeleteMethod::BuiltIn(Method::default()))
-			.build();
+    #[test]
+    fn build_fails_when_path_is_missing() {
+        let result = DeleteRequestBuilder::new()
+            .method(DeleteMethod::BuiltIn(Method::default()))
+            .build();
 
-		let err = result.expect_err("builder should fail without path");
+        let err = result.expect_err("builder should fail without path");
 
-		assert_eq!(err, Error::MissingParameter("path"));
-	}
+        assert_eq!(err, Error::MissingParameter("path"));
+    }
 
-	#[test]
-	fn build_fails_when_method_is_missing() {
-		let result = DeleteRequestBuilder::new()
-			.path(PathBuf::from("/tmp/file.txt"))
-			.build();
+    #[test]
+    fn build_fails_when_method_is_missing() {
+        let result = DeleteRequestBuilder::new()
+            .path(PathBuf::from("/tmp/file.txt"))
+            .build();
 
-		let err = result.expect_err("builder should fail without method");
+        let err = result.expect_err("builder should fail without method");
 
-		assert_eq!(err, Error::MissingParameter("method"));
-	}
+        assert_eq!(err, Error::MissingParameter("method"));
+    }
 
-	#[test]
-	fn build_succeeds_when_all_parameters_are_present() {
-		let result = DeleteRequestBuilder::new()
-			.path(PathBuf::from("/tmp/file.txt"))
-			.method(DeleteMethod::BuiltIn(Method::default()))
-			.build();
+    #[test]
+    fn build_succeeds_when_all_parameters_are_present() {
+        let result = DeleteRequestBuilder::new()
+            .path(PathBuf::from("/tmp/file.txt"))
+            .method(DeleteMethod::BuiltIn(Method::default()))
+            .build();
 
-		assert!(result.is_ok());
-	}
+        assert!(result.is_ok());
+    }
 }
 
 #[cfg(feature = "error-stack")]
 impl DeleteRequestBuilder {
-	pub fn build(self) -> Result<DeleteRequest> {
-		let path = self.path.ok_or(Error::MissingParameter("path"))?;
-		let method = self.method.ok_or(Error::MissingParameter("method"))?;
-		Ok(DeleteRequest { path, method })
-	}
+    pub fn build(self) -> Result<DeleteRequest> {
+        let path = self.path.ok_or(Error::MissingParameter("path"))?;
+        let method = self.method.ok_or(Error::MissingParameter("method"))?;
+        Ok(DeleteRequest { path, method })
+    }
 }
 
 #[cfg(all(test, feature = "error-stack"))]
 mod tests {
-	use super::*;
-	use crate::Method;
-	use crate::api::delete::request::DeleteMethod ;
-	use error_stack::Frame;
-	use std::path::PathBuf;
+    use super::*;
+    use crate::Method;
+    use crate::api::delete::request::DeleteMethod;
+    use error_stack::Frame;
+    use std::path::PathBuf;
 
-	#[test]
-	fn build_fails_when_path_is_missing() {
+    #[test]
+    fn build_fails_when_path_is_missing() {
+        let result = DeleteRequestBuilder::new()
+            .method(DeleteMethod::BuiltIn(Method::default()))
+            .build();
 
-		let result = DeleteRequestBuilder::new()
-			.method(DeleteMethod::BuiltIn(Method::default()))
-			.build();
+        assert!(result.is_err());
 
-		assert!(result.is_err());
+        let err = result.unwrap_err();
 
-		let err = result.unwrap_err();
+        assert!(err.frames().any(|frame| {
+            frame
+                .downcast_ref::<Error>()
+                .is_some_and(|e| matches!(e, Error::MissingParameter("path")))
+        }));
+    }
 
-		assert!(err.frames().any(|frame| {
-			frame
-				.downcast_ref::<Error>()
-				.is_some_and(|e| matches!(e, Error::MissingParameter("path")))
-		}));
-	}
+    #[test]
+    fn build_fails_when_method_is_missing() {
+        use std::path::PathBuf;
 
-	#[test]
-	fn build_fails_when_method_is_missing() {
-		use std::path::PathBuf;
+        let result = DeleteRequestBuilder::new()
+            .path(PathBuf::from("/tmp/file.txt"))
+            .build();
 
-		let result = DeleteRequestBuilder::new()
-			.path(PathBuf::from("/tmp/file.txt"))
-			.build();
+        assert!(result.is_err());
 
-		assert!(result.is_err());
+        let err = result.unwrap_err();
 
-		let err = result.unwrap_err();
+        assert!(err.frames().any(|frame| {
+            frame
+                .downcast_ref::<Error>()
+                .is_some_and(|e| matches!(e, Error::MissingParameter("method")))
+        }));
+    }
 
-		assert!(err.frames().any(|frame| {
-			frame
-				.downcast_ref::<Error>()
-				.is_some_and(|e| matches!(e, Error::MissingParameter("method")))
-		}));
-	}
+    #[test]
+    fn build_succeeds_when_all_parameters_are_present() {
+        use std::path::PathBuf;
 
-	#[test]
-	fn build_succeeds_when_all_parameters_are_present() {
-		use std::path::PathBuf;
+        let result = DeleteRequestBuilder::new()
+            .path(PathBuf::from("/tmp/file.txt"))
+            .method(DeleteMethod::BuiltIn(Method::default()))
+            .build();
 
-		let result = DeleteRequestBuilder::new()
-			.path(PathBuf::from("/tmp/file.txt"))
-			.method(DeleteMethod::BuiltIn(Method::default()))
-			.build();
-
-		assert!(result.is_ok());
-	}
+        assert!(result.is_ok());
+    }
 }

--- a/src/api/delete/legacy.rs
+++ b/src/api/delete/legacy.rs
@@ -3,46 +3,47 @@ use crate::SecureDelete;
 use super::builder::DeleteRequestBuilder;
 
 impl From<SecureDelete> for DeleteRequestBuilder {
-	fn from(sd: SecureDelete) -> Self {
-		DeleteRequestBuilder::new()
-			.path(sd.path)
-	}
+    fn from(sd: SecureDelete) -> Self {
+        DeleteRequestBuilder::new().path(sd.path)
+    }
 }
 
 #[cfg(test)]
-mod tests{
-	use std::fs::File;
-	use crate::api::delete::DeleteRequestBuilder;
-	use crate::{Error, SecureDelete};
-	use pretty_assertions::assert_eq;
+mod tests {
+    use crate::api::delete::DeleteRequestBuilder;
+    use crate::{Error, SecureDelete};
+    use pretty_assertions::assert_eq;
+    use std::fs::File;
 
-	#[cfg(not(feature = "error-stack"))]
-	use crate::Result;
+    #[cfg(not(feature = "error-stack"))]
+    use crate::Result;
 
-	#[cfg(feature = "error-stack")]
-	use error_stack::{Report, ResultExt};
-	#[cfg(feature = "error-stack")]
-	use crate::Result;
+    #[cfg(feature = "error-stack")]
+    use crate::Result;
+    #[cfg(feature = "error-stack")]
+    use error_stack::{Report, ResultExt};
 
-	#[test]
-	#[cfg(not(feature = "error-stack"))]
-	fn from() -> Result<()>{
-		File::create("/tmp/request_builder_from").map_err(|e| Error::FileCreationError(e))?;
-		let tested = SecureDelete::new("/tmp/request_builder_from")?;
-		let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
-		assert_eq!(wanted,DeleteRequestBuilder::from(tested));
-		std::fs::remove_file("/tmp/request_builder_from").map_err(|e| Error::FileCreationError(e))?;
-		Ok(())
-	}
+    #[test]
+    #[cfg(not(feature = "error-stack"))]
+    fn from() -> Result<()> {
+        File::create("/tmp/request_builder_from").map_err(|e| Error::FileCreationError(e))?;
+        let tested = SecureDelete::new("/tmp/request_builder_from")?;
+        let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
+        assert_eq!(wanted, DeleteRequestBuilder::from(tested));
+        std::fs::remove_file("/tmp/request_builder_from")
+            .map_err(|e| Error::FileCreationError(e))?;
+        Ok(())
+    }
 
-	#[test]
-	#[cfg(feature = "error-stack")]
-	fn from() -> Result<()>{
-		File::create("/tmp/request_builder_from").change_context(Error::FileCreationError)?;
-		let tested = SecureDelete::new("/tmp/request_builder_from")?;
-		let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
-		assert_eq!(wanted,DeleteRequestBuilder::from(tested));
-		std::fs::remove_file("/tmp/request_builder_from").change_context(Error::FileCreationError)?;
-		Ok(())
-	}
+    #[test]
+    #[cfg(feature = "error-stack")]
+    fn from() -> Result<()> {
+        File::create("/tmp/request_builder_from").change_context(Error::FileCreationError)?;
+        let tested = SecureDelete::new("/tmp/request_builder_from")?;
+        let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
+        assert_eq!(wanted, DeleteRequestBuilder::from(tested));
+        std::fs::remove_file("/tmp/request_builder_from")
+            .change_context(Error::FileCreationError)?;
+        Ok(())
+    }
 }

--- a/src/api/delete/legacy.rs
+++ b/src/api/delete/legacy.rs
@@ -19,6 +19,11 @@ mod tests{
 	#[cfg(not(feature = "error-stack"))]
 	use crate::Result;
 
+	#[cfg(feature = "error-stack")]
+	use error_stack::{Report, ResultExt};
+	#[cfg(feature = "error-stack")]
+	use crate::Result;
+
 	#[test]
 	#[cfg(not(feature = "error-stack"))]
 	fn from() -> Result<()>{
@@ -30,4 +35,14 @@ mod tests{
 		Ok(())
 	}
 
+	#[test]
+	#[cfg(feature = "error-stack")]
+	fn from() -> Result<()>{
+		File::create("/tmp/request_builder_from").change_context(Error::FileCreationError)?;
+		let tested = SecureDelete::new("/tmp/request_builder_from")?;
+		let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
+		assert_eq!(wanted,DeleteRequestBuilder::from(tested));
+		std::fs::remove_file("/tmp/request_builder_from").change_context(Error::FileCreationError)?;
+		Ok(())
+	}
 }

--- a/src/api/delete/legacy.rs
+++ b/src/api/delete/legacy.rs
@@ -1,0 +1,33 @@
+use crate::SecureDelete;
+
+use super::builder::DeleteRequestBuilder;
+
+impl From<SecureDelete> for DeleteRequestBuilder {
+	fn from(sd: SecureDelete) -> Self {
+		DeleteRequestBuilder::new()
+			.path(sd.path)
+	}
+}
+
+#[cfg(test)]
+mod tests{
+	use std::fs::File;
+	use crate::api::delete::DeleteRequestBuilder;
+	use crate::{Error, SecureDelete};
+	use pretty_assertions::assert_eq;
+
+	#[cfg(not(feature = "error-stack"))]
+	use crate::Result;
+
+	#[test]
+	#[cfg(not(feature = "error-stack"))]
+	fn from() -> Result<()>{
+		File::create("/tmp/request_builder_from").map_err(|e| Error::FileCreationError(e))?;
+		let tested = SecureDelete::new("/tmp/request_builder_from")?;
+		let wanted = DeleteRequestBuilder::new().path("/tmp/request_builder_from");
+		assert_eq!(wanted,DeleteRequestBuilder::from(tested));
+		std::fs::remove_file("/tmp/request_builder_from").map_err(|e| Error::FileCreationError(e))?;
+		Ok(())
+	}
+
+}

--- a/src/api/delete/mod.rs
+++ b/src/api/delete/mod.rs
@@ -1,9 +1,9 @@
-pub mod request;
 pub mod builder;
-pub mod report;
 pub mod legacy;
+pub mod report;
+pub mod request;
 
-pub use request::DeleteRequest;
 pub use builder::DeleteRequestBuilder;
 pub use report::DeleteReport;
 pub use request::DeleteMethod;
+pub use request::DeleteRequest;

--- a/src/api/delete/mod.rs
+++ b/src/api/delete/mod.rs
@@ -1,0 +1,9 @@
+pub mod request;
+pub mod builder;
+pub mod report;
+pub mod legacy;
+
+pub use request::DeleteRequest;
+pub use builder::DeleteRequestBuilder;
+pub use report::DeleteReport;
+pub use request::DeleteMethod;

--- a/src/api/delete/report.rs
+++ b/src/api/delete/report.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
 use crate::Method;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct DeleteReport {
-	pub path: PathBuf,
-	pub method: Method,
+    pub path: PathBuf,
+    pub method: Method,
 }

--- a/src/api/delete/report.rs
+++ b/src/api/delete/report.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+use crate::Method;
+
+#[derive(Debug, Clone)]
+pub struct DeleteReport {
+	pub path: PathBuf,
+	pub method: Method,
+}

--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use crate::api::delete::{DeleteReport, DeleteRequestBuilder};
+use crate::Method;
+use crate::engine;
+
+#[cfg(not(feature = "error-stack"))]
+use crate::Result;
+
+#[derive(Debug)]
+#[cfg_attr(test,derive(PartialEq))]
+pub struct DeleteRequest {
+	pub(crate) path: PathBuf,
+	pub(crate) method: DeleteMethod,
+}
+
+#[derive(Debug)]
+#[cfg_attr(test,derive(PartialEq))]
+pub enum DeleteMethod {
+	BuiltIn(Method),
+}
+
+impl DeleteRequest {
+	pub fn builder() -> DeleteRequestBuilder {
+		DeleteRequestBuilder::new()
+	}
+}
+
+#[cfg(not(feature = "error-stack"))]
+impl DeleteRequest {
+
+	pub fn run(&self) -> Result<DeleteReport> {
+		match &self.method {
+			DeleteMethod::BuiltIn(method) => {
+				engine::run(method, &self.path)?;
+				Ok(DeleteReport {
+					path: self.path.clone(),
+					method: *method,
+				})
+			}
+		}
+	}
+
+}
+
+
+#[cfg(test)]
+mod test{
+	use crate::api::delete::DeleteRequestBuilder;
+	use crate::DeleteRequest;
+	use pretty_assertions::assert_eq;
+
+	#[test]
+	fn delete_request() {
+		let req_builder = DeleteRequest::builder();
+		let delete_builder = DeleteRequestBuilder::new();
+		assert_eq!(req_builder,delete_builder);
+
+	}
+}

--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-use crate::api::delete::{DeleteReport, DeleteRequestBuilder};
 use crate::Method;
+use crate::api::delete::{DeleteReport, DeleteRequestBuilder};
 use crate::engine;
+use std::path::PathBuf;
 
 #[cfg(not(feature = "error-stack"))]
 use crate::Result;
@@ -9,69 +9,64 @@ use crate::Result;
 use crate::Result;
 
 #[derive(Debug)]
-#[cfg_attr(test,derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct DeleteRequest {
-	pub(crate) path: PathBuf,
-	pub(crate) method: DeleteMethod,
+    pub(crate) path: PathBuf,
+    pub(crate) method: DeleteMethod,
 }
 
 #[derive(Debug)]
-#[cfg_attr(test,derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum DeleteMethod {
-	BuiltIn(Method),
+    BuiltIn(Method),
 }
 
 impl DeleteRequest {
-	pub fn builder() -> DeleteRequestBuilder {
-		DeleteRequestBuilder::new()
-	}
+    pub fn builder() -> DeleteRequestBuilder {
+        DeleteRequestBuilder::new()
+    }
 }
 
 #[cfg(not(feature = "error-stack"))]
 impl DeleteRequest {
-
-	pub fn run(&self) -> Result<DeleteReport> {
-		match &self.method {
-			DeleteMethod::BuiltIn(method) => {
-				engine::run(method, &self.path)?;
-				Ok(DeleteReport {
-					path: self.path.clone(),
-					method: *method,
-				})
-			}
-		}
-	}
-
+    pub fn run(&self) -> Result<DeleteReport> {
+        match &self.method {
+            DeleteMethod::BuiltIn(method) => {
+                engine::run(method, &self.path)?;
+                Ok(DeleteReport {
+                    path: self.path.clone(),
+                    method: *method,
+                })
+            }
+        }
+    }
 }
 
 #[cfg(feature = "error-stack")]
 impl DeleteRequest {
-
-	pub fn run(&self) -> Result<DeleteReport> {
-		match &self.method {
-			DeleteMethod::BuiltIn(method) => {
-				engine::run(method, &self.path)?;
-				Ok(DeleteReport {
-					path: self.path.clone(),
-					method: *method,
-				})
-			}
-		}
-	}
-
+    pub fn run(&self) -> Result<DeleteReport> {
+        match &self.method {
+            DeleteMethod::BuiltIn(method) => {
+                engine::run(method, &self.path)?;
+                Ok(DeleteReport {
+                    path: self.path.clone(),
+                    method: *method,
+                })
+            }
+        }
+    }
 }
 
 #[cfg(test)]
-mod test{
-	use crate::api::delete::DeleteRequestBuilder;
-	use crate::DeleteRequest;
-	use pretty_assertions::assert_eq;
+mod test {
+    use crate::DeleteRequest;
+    use crate::api::delete::DeleteRequestBuilder;
+    use pretty_assertions::assert_eq;
 
-	#[test]
-	fn delete_request() {
-		let req_builder = DeleteRequest::builder();
-		let delete_builder = DeleteRequestBuilder::new();
-		assert_eq!(req_builder,delete_builder);
-
-	}
+    #[test]
+    fn delete_request() {
+        let req_builder = DeleteRequest::builder();
+        let delete_builder = DeleteRequestBuilder::new();
+        assert_eq!(req_builder, delete_builder);
+    }
 }

--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -5,6 +5,8 @@ use crate::engine;
 
 #[cfg(not(feature = "error-stack"))]
 use crate::Result;
+#[cfg(feature = "error-stack")]
+use crate::Result;
 
 #[derive(Debug)]
 #[cfg_attr(test,derive(PartialEq))]
@@ -42,6 +44,22 @@ impl DeleteRequest {
 
 }
 
+#[cfg(feature = "error-stack")]
+impl DeleteRequest {
+
+	pub fn run(&self) -> Result<DeleteReport> {
+		match &self.method {
+			DeleteMethod::BuiltIn(method) => {
+				engine::run(method, &self.path)?;
+				Ok(DeleteReport {
+					path: self.path.clone(),
+					method: *method,
+				})
+			}
+		}
+	}
+
+}
 
 #[cfg(test)]
 mod test{

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod delete;

--- a/src/error/enhanced.rs
+++ b/src/error/enhanced.rs
@@ -19,6 +19,7 @@ pub enum Error {
     /// error to help during debug phase
     #[cfg(test)]
     FileCreationError,
+    MissingParameter(&'static str),
 }
 
 /// Implementing display trait for Error enum
@@ -42,6 +43,9 @@ impl core::fmt::Display for Error {
                 fmt,
                 "File Creation : Error during test file generation process"
             ),
+            Error::MissingParameter(param) => {
+                write!(fmt, "RequestDeleter : {param} params missing")
+            }
         }
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -6,7 +6,7 @@ pub mod enhanced;
 
 /// Enum that represent different kind of file system problem that Nozomi lib can encounter
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(test,derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum FSProblem {
     /// Problem during rename process
     Rename,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -6,6 +6,7 @@ pub mod enhanced;
 
 /// Enum that represent different kind of file system problem that Nozomi lib can encounter
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(test,derive(PartialEq))]
 pub enum FSProblem {
     /// Problem during rename process
     Rename,

--- a/src/error/standard.rs
+++ b/src/error/standard.rs
@@ -19,6 +19,7 @@ pub enum Error {
     /// Wrapper for std::io:Error to help during debug phase
     #[cfg(test)]
     FileCreationError(std::io::Error),
+    MissingParameter(&'static str),
 }
 
 /// Implementing display trait for Error enum
@@ -39,6 +40,7 @@ impl core::fmt::Display for Error {
             }
             #[cfg(test)]
             Error::FileCreationError(e) => write!(fmt, "{e:?}"),
+            Error::MissingParameter(param) => {write!(fmt, "RequestDeleter : {param} params missing")}
         }
     }
 }
@@ -53,5 +55,25 @@ mod test {
     #[test]
     fn test_rfc1236() {
         rfc1236::<super::Error>();
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        use Error::*;
+
+        match (self, other) {
+            (SystemProblem(a1, b1), SystemProblem(a2, b2)) => a1 == a2 && b1 == b2,
+            (OverwriteError(m1, s1), OverwriteError(m2, s2)) => m1 == m2 && s1 == s2,
+            (NoFileName(_), NoFileName(_)) => true, // or false, see note below
+            (StringConversionError, StringConversionError) => true,
+            (MissingParameter(p1), MissingParameter(p2)) => p1 == p2,
+
+            // 👇 IMPORTANT: FileCreationError is never equal
+            (FileCreationError(_), FileCreationError(_)) => false,
+
+            _ => false,
+        }
     }
 }

--- a/src/error/standard.rs
+++ b/src/error/standard.rs
@@ -40,7 +40,9 @@ impl core::fmt::Display for Error {
             }
             #[cfg(test)]
             Error::FileCreationError(e) => write!(fmt, "{e:?}"),
-            Error::MissingParameter(param) => {write!(fmt, "RequestDeleter : {param} params missing")}
+            Error::MissingParameter(param) => {
+                write!(fmt, "RequestDeleter : {param} params missing")
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@ mod models;
 #[cfg(test)]
 mod tests;
 
-mod engine;
 pub mod api;
+mod engine;
+pub use api::delete::DeleteMethod;
+pub use api::delete::DeleteReport;
 pub use api::delete::DeleteRequest;
 pub use api::delete::DeleteRequestBuilder;
-pub use api::delete::DeleteReport;
-pub use api::delete::DeleteMethod;
 
 // -- Export object
 pub use crate::methods::Method;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,11 @@ mod models;
 mod tests;
 
 mod engine;
+pub mod api;
+pub use api::delete::DeleteRequest;
+pub use api::delete::DeleteRequestBuilder;
+pub use api::delete::DeleteReport;
+pub use api::delete::DeleteMethod;
 
 // -- Export object
 pub use crate::methods::Method;

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,7 +20,7 @@ use log::trace;
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct SecureDelete {
     /// File/Folder path that you want to overwrite/delete
-    path: String,
+    pub(crate) path: String,
     /// Array of 3 Bytes that can be used to overwrite a file. Is none if byte is something
     pattern: Option<[u8; 3]>,
     /// A byte that will be used to overwrite a file. Is none if pattern is something

--- a/tests/test_export.rs
+++ b/tests/test_export.rs
@@ -6,6 +6,9 @@ fn api_export() {
     use nozomi::Method;
     use nozomi::SecureDelete;
 
+    #[cfg(feature = "error-stack")]
+    use nozomi::DeleteRequest;
+
     Method::Dod522022ME;
     nozomi::Method::Afssi5020;
 


### PR DESCRIPTION
## 🚀 What’s New

- Public API additions
- `DeleteRequest`
- `DeleteRequestBuilder`
- `DeleteMethod`
- `DeleteReport`

## ♻️ Legacy Compatibility (Issue #9)

- Implemented `From<SecureDelete>` for `DeleteRequestBuilder`
- Added new error variants to the legacy error system
- Implemented all methods requested in Issue #9
- Legacy APIs remain supported and unchanged in behavior

## 🔧 Internal Changes

- Temporarily moved the SecureDelete path variable to pub(crate)
- Required for safe internal conversions
- Does not expand the public API surface
- No changes to deletion execution logic

## 🧩 API Design Notes

- Public types are re-exported explicitly to keep the API flat and stable
- Internal module structure (api::delete) is not part of the public contract
- This allows internal refactors without breaking downstream users

## ✅ Compatibility & Status

- No breaking changes
- Fully additive PR
- All tests passing

## Follow-ups:
- PR-3: Event system
- PR-4+: Feature gating, deprecations, documentation