### PR TITLE
Feature: introduce event-driven execution model (#10)

### DIFF
--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::api::delete::{DeleteReport, DeleteRequestBuilder};
 use crate::engine;
 use std::path::PathBuf;
@@ -30,9 +30,41 @@ impl DeleteRequest {
 #[cfg(not(feature = "error-stack"))]
 impl DeleteRequest {
     pub fn run(&self) -> Result<DeleteReport> {
+        let mut sink = NoopSink;
+        self.run_with(&mut sink)
+    }
+
+    pub fn run_with<S: EventSink>(
+        &self,
+        sink: &mut S,
+    ) -> Result<DeleteReport> {
         match &self.method {
             DeleteMethod::BuiltIn(method) => {
-                engine::run(method, &self.path)?;
+                engine::run(method, &self.path,sink)?;
+                Ok(DeleteReport {
+                    path: self.path.clone(),
+                    method: *method,
+                })
+            }
+        }
+    }
+
+}
+
+#[cfg(feature = "error-stack")]
+impl DeleteRequest {
+    pub fn run(&self) -> Result<DeleteReport> {
+        let mut sink = NoopSink;
+        self.run_with(&mut sink)
+    }
+
+    pub fn run_with<S: EventSink>(
+        &self,
+        sink: &mut S,
+    ) -> Result<DeleteReport> {
+        match &self.method {
+            DeleteMethod::BuiltIn(method) => {
+                engine::run(method, &self.path,sink)?;
                 Ok(DeleteReport {
                     path: self.path.clone(),
                     method: *method,
@@ -42,19 +74,11 @@ impl DeleteRequest {
     }
 }
 
-#[cfg(feature = "error-stack")]
-impl DeleteRequest {
-    pub fn run(&self) -> Result<DeleteReport> {
-        match &self.method {
-            DeleteMethod::BuiltIn(method) => {
-                engine::run(method, &self.path)?;
-                Ok(DeleteReport {
-                    path: self.path.clone(),
-                    method: *method,
-                })
-            }
-        }
-    }
+
+pub(crate) struct NoopSink;
+
+impl EventSink for NoopSink {
+    fn emit(&mut self, _: DeleteEvent) {}
 }
 
 #[cfg(test)]

--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -1,6 +1,6 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::api::delete::{DeleteReport, DeleteRequestBuilder};
 use crate::engine;
+use crate::{DeleteEvent, EventSink, Method};
 use std::path::PathBuf;
 
 #[cfg(not(feature = "error-stack"))]
@@ -34,13 +34,10 @@ impl DeleteRequest {
         self.run_with(&mut sink)
     }
 
-    pub fn run_with<S: EventSink>(
-        &self,
-        sink: &mut S,
-    ) -> Result<DeleteReport> {
+    pub fn run_with<S: EventSink>(&self, sink: &mut S) -> Result<DeleteReport> {
         match &self.method {
             DeleteMethod::BuiltIn(method) => {
-                engine::run(method, &self.path,sink)?;
+                engine::run(method, &self.path, sink)?;
                 Ok(DeleteReport {
                     path: self.path.clone(),
                     method: *method,
@@ -48,7 +45,6 @@ impl DeleteRequest {
             }
         }
     }
-
 }
 
 #[cfg(feature = "error-stack")]
@@ -58,13 +54,10 @@ impl DeleteRequest {
         self.run_with(&mut sink)
     }
 
-    pub fn run_with<S: EventSink>(
-        &self,
-        sink: &mut S,
-    ) -> Result<DeleteReport> {
+    pub fn run_with<S: EventSink>(&self, sink: &mut S) -> Result<DeleteReport> {
         match &self.method {
             DeleteMethod::BuiltIn(method) => {
-                engine::run(method, &self.path,sink)?;
+                engine::run(method, &self.path, sink)?;
                 Ok(DeleteReport {
                     path: self.path.clone(),
                     method: *method,
@@ -73,7 +66,6 @@ impl DeleteRequest {
         }
     }
 }
-
 
 pub(crate) struct NoopSink;
 

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -3,35 +3,29 @@ use std::path::PathBuf;
 /// Structured execution events emitted during deletion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeleteEvent {
-	/// Deletion process has started for a given path
-	DeletionStarted {
-		path: PathBuf,
-	},
-	/// A filesystem entry has been successfully overwritten
-	EntryOverwritePass {
-		path: PathBuf,
-		pass: u32,
-		total_passes: u32,
-	},
+    /// Deletion process has started for a given path
+    DeletionStarted { path: PathBuf },
+    /// A filesystem entry has been successfully overwritten
+    EntryOverwritePass {
+        path: PathBuf,
+        pass: u32,
+        total_passes: u32,
+    },
 
-	/// A filesystem entry has been successfully deleted
-	EntryDeleted {
-		path: PathBuf,
-	},
+    /// A filesystem entry has been successfully deleted
+    EntryDeleted { path: PathBuf },
 
-	/// Deletion process has finished
-	DeletionFinished {
-		path: PathBuf,
-	},
+    /// Deletion process has finished
+    DeletionFinished { path: PathBuf },
 }
 
 /// Sink for deletion execution events.
 ///
 /// Any failure inside the sink must not affect deletion execution.
 pub trait EventSink {
-	/// Emit a structured deletion event.
-	///
-	/// This method must never influence control flow.
-	/// Panics inside implementations will be caught by the engine.
-	fn emit(&mut self, event: DeleteEvent);
+    /// Emit a structured deletion event.
+    ///
+    /// This method must never influence control flow.
+    /// Panics inside implementations will be caught by the engine.
+    fn emit(&mut self, event: DeleteEvent);
 }

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+/// Structured execution events emitted during deletion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteEvent {
+	/// Deletion process has started for a given path
+	DeletionStarted {
+		path: PathBuf,
+	},
+	/// A filesystem entry has been successfully overwritten
+	EntryOverwritePass {
+		path: PathBuf,
+		pass: u32,
+		total_passes: u32,
+	},
+
+	/// A filesystem entry has been successfully deleted
+	EntryDeleted {
+		path: PathBuf,
+	},
+
+	/// Deletion process has finished
+	DeletionFinished {
+		path: PathBuf,
+	},
+}
+
+/// Sink for deletion execution events.
+///
+/// Any failure inside the sink must not affect deletion execution.
+pub trait EventSink {
+	/// Emit a structured deletion event.
+	///
+	/// This method must never influence control flow.
+	/// Panics inside implementations will be caught by the engine.
+	fn emit(&mut self, event: DeleteEvent);
+}

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -17,7 +17,7 @@ use error_stack::ResultExt;
 use log::info;
 
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(
         sink,
         DeleteEvent::DeletionStarted {
@@ -25,31 +25,33 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> R
         },
     );
     let result = (|| {
-    let plan = planner::execution_plan(path)?;
+        let plan = planner::execution_plan(path)?;
 
-    for file_path in &plan.files {
-        overwrite::overwrite_file(method, file_path, sink)?;
-    }
+        for file_path in &plan.files {
+            overwrite::overwrite_file(method, file_path, sink)?;
+        }
 
-    for file_path in &plan.files {
-        delete_file(file_path)?;
-        emit_safe(
-            sink,
-            DeleteEvent::EntryDeleted { path: file_path.clone() },
-        );
+        for file_path in &plan.files {
+            delete_file(file_path)?;
+            emit_safe(
+                sink,
+                DeleteEvent::EntryDeleted {
+                    path: file_path.clone(),
+                },
+            );
+        }
 
-    }
+        for dir_path in plan.directories.iter().rev() {
+            delete_dir(dir_path)?;
+            emit_safe(
+                sink,
+                DeleteEvent::EntryDeleted {
+                    path: dir_path.clone(),
+                },
+            );
+        }
 
-    for dir_path in plan.directories.iter().rev() {
-        delete_dir(dir_path)?;
-        emit_safe(
-            sink,
-            DeleteEvent::EntryDeleted { path: dir_path.clone() },
-        );
-
-    }
-
-    Ok(())
+        Ok(())
     })();
 
     emit_safe(
@@ -60,11 +62,10 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> R
     );
 
     result
-
 }
 
 #[cfg(feature = "error-stack")]
-pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(
         sink,
         DeleteEvent::DeletionStarted {
@@ -73,28 +74,32 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> R
     );
 
     let result = (|| {
-    let plan = planner::execution_plan(path)?;
+        let plan = planner::execution_plan(path)?;
 
-    for file_path in &plan.files {
-        overwrite::overwrite_file(method, file_path, sink)?;
-    }
+        for file_path in &plan.files {
+            overwrite::overwrite_file(method, file_path, sink)?;
+        }
 
-    for file_path in &plan.files {
-        delete_file(file_path)?;
-        emit_safe(
-            sink,
-            DeleteEvent::EntryDeleted { path: file_path.clone() },
-        );
-    }
+        for file_path in &plan.files {
+            delete_file(file_path)?;
+            emit_safe(
+                sink,
+                DeleteEvent::EntryDeleted {
+                    path: file_path.clone(),
+                },
+            );
+        }
 
-    for dir_path in plan.directories.iter().rev() {
-        delete_dir(dir_path)?;
-        emit_safe(
-            sink,
-            DeleteEvent::EntryDeleted { path: dir_path.clone() },
-        );
-    }
-    Ok(())
+        for dir_path in plan.directories.iter().rev() {
+            delete_dir(dir_path)?;
+            emit_safe(
+                sink,
+                DeleteEvent::EntryDeleted {
+                    path: dir_path.clone(),
+                },
+            );
+        }
+        Ok(())
     })();
 
     emit_safe(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -28,7 +28,7 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> R
     let plan = planner::execution_plan(path)?;
 
     for file_path in &plan.files {
-        overwrite::overwrite_file(method, file_path)?;
+        overwrite::overwrite_file(method, file_path, sink)?;
     }
 
     for file_path in &plan.files {
@@ -76,7 +76,7 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> R
     let plan = planner::execution_plan(path)?;
 
     for file_path in &plan.files {
-        overwrite::overwrite_file(method, file_path)?;
+        overwrite::overwrite_file(method, file_path, sink)?;
     }
 
     for file_path in &plan.files {

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1,9 +1,9 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use std::path::Path;
 
 use super::overwrite;
 use super::planner;
-use crate::engine::utils::{delete_dir, delete_file};
+use crate::engine::utils::{delete_dir, delete_file, emit_safe};
 
 #[cfg(not(feature = "error-stack"))]
 use crate::Result;
@@ -17,7 +17,14 @@ use error_stack::ResultExt;
 use log::info;
 
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn run(method: &Method, path: &Path) -> Result<()> {
+pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+    emit_safe(
+        sink,
+        DeleteEvent::DeletionStarted {
+            path: path.to_path_buf(),
+        },
+    );
+    let result = (|| {
     let plan = planner::execution_plan(path)?;
 
     for file_path in &plan.files {
@@ -26,16 +33,46 @@ pub(crate) fn run(method: &Method, path: &Path) -> Result<()> {
 
     for file_path in &plan.files {
         delete_file(file_path)?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryDeleted { path: file_path.clone() },
+        );
+
     }
 
     for dir_path in plan.directories.iter().rev() {
         delete_dir(dir_path)?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryDeleted { path: dir_path.clone() },
+        );
+
     }
+
     Ok(())
+    })();
+
+    emit_safe(
+        sink,
+        DeleteEvent::DeletionFinished {
+            path: path.to_path_buf(),
+        },
+    );
+
+    result
+
 }
 
 #[cfg(feature = "error-stack")]
-pub(crate) fn run(method: &Method, path: &Path) -> Result<()> {
+pub(crate) fn run<S: EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+    emit_safe(
+        sink,
+        DeleteEvent::DeletionStarted {
+            path: path.to_path_buf(),
+        },
+    );
+
+    let result = (|| {
     let plan = planner::execution_plan(path)?;
 
     for file_path in &plan.files {
@@ -44,10 +81,28 @@ pub(crate) fn run(method: &Method, path: &Path) -> Result<()> {
 
     for file_path in &plan.files {
         delete_file(file_path)?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryDeleted { path: file_path.clone() },
+        );
     }
 
     for dir_path in plan.directories.iter().rev() {
         delete_dir(dir_path)?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryDeleted { path: dir_path.clone() },
+        );
     }
     Ok(())
+    })();
+
+    emit_safe(
+        sink,
+        DeleteEvent::DeletionFinished {
+            path: path.to_path_buf(),
+        },
+    );
+
+    result
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5,9 +5,9 @@
 // The engine currently propagates legacy error types to preserve
 // exact behavior. Error decoupling is intentionally deferred.
 
+pub(crate) mod events;
 mod executor;
 mod overwrite;
 mod planner;
 mod utils;
-pub(crate) mod events;
 pub(crate) use executor::run;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,5 +9,5 @@ mod executor;
 mod overwrite;
 mod planner;
 mod utils;
-
+pub(crate) mod events;
 pub(crate) use executor::run;

--- a/src/engine/overwrite/afssi_5020.rs
+++ b/src/engine/overwrite/afssi_5020.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -29,7 +30,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -57,6 +58,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Afssi5020, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32+1,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -74,7 +83,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -102,6 +111,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .change_context(Error::OverwriteError(Method::Afssi5020, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32+1,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -117,7 +134,6 @@ mod test {
     use crate::Method::Afssi5020 as EraseMethod;
     const METHOD_NAME: &str = "afssi_5020";
 
-    use super::overwrite_file;
     use crate::error::FSProblem;
     use crate::tests::TestType;
 
@@ -133,7 +149,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -149,7 +165,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -301,7 +318,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -317,7 +335,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/afssi_5020.rs
+++ b/src/engine/overwrite/afssi_5020.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -30,7 +30,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -62,9 +62,9 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             sink,
             DeleteEvent::EntryOverwritePass {
                 path: path.to_path_buf(),
-                pass: pass as u32+1,
+                pass: pass as u32 + 1,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().map_err(|_| {
@@ -83,7 +83,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -115,9 +115,9 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             sink,
             DeleteEvent::EntryOverwritePass {
                 path: path.to_path_buf(),
-                pass: pass as u32+1,
+                pass: pass as u32 + 1,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().change_context(Error::SystemProblem(
@@ -147,10 +147,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -166,7 +166,10 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(
+                    &path.to_path_buf(),
+                    &mut sink,
+                )?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -315,12 +318,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_me::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -336,7 +339,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/dod_522022_me.rs
+++ b/src/engine/overwrite/dod_522022_me.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -29,7 +30,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -57,6 +58,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Dod522022ME, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -74,7 +83,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -102,6 +111,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .change_context(Error::OverwriteError(Method::Dod522022ME, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -133,7 +150,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -149,7 +166,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -301,7 +319,7 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -317,7 +335,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/dod_522022_me.rs
+++ b/src/engine/overwrite/dod_522022_me.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -30,7 +30,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -64,7 +64,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: pass as u32,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().map_err(|_| {
@@ -83,7 +83,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -117,7 +117,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: pass as u32,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().change_context(Error::SystemProblem(
@@ -148,10 +148,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -167,7 +167,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -316,11 +316,11 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -336,7 +336,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/dod_522022_mece.rs
+++ b/src/engine/overwrite/dod_522022_mece.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[
     Some(0x00),
@@ -38,7 +38,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[
 /// ## Return
 /// * `secure_deletion` (SecureDelete) : An SecureDelete object
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -73,7 +73,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: pass as u32,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().map_err(|_| {
@@ -92,7 +92,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `secure_deletion` (SecureDelete) : An SecureDelete object
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -127,7 +127,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: pass as u32,
                 total_passes: FIXED_PATTERNS.len() as u32,
-            }
+            },
         );
     }
     file.sync_all().change_context(Error::SystemProblem(
@@ -158,10 +158,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -177,7 +177,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -326,12 +326,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_mece::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_mece::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -347,7 +347,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/dod_522022_mece.rs
+++ b/src/engine/overwrite/dod_522022_mece.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[
     Some(0x00),
@@ -37,7 +38,7 @@ const FIXED_PATTERNS: &[Option<u8>] = &[
 /// ## Return
 /// * `secure_deletion` (SecureDelete) : An SecureDelete object
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -66,6 +67,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
         // flush after each pass (best-effort)
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Dod522022MECE, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -83,7 +92,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `secure_deletion` (SecureDelete) : An SecureDelete object
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
@@ -112,6 +121,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
         // flush after each pass (best-effort)
         file.flush()
             .change_context(Error::OverwriteError(Method::Dod522022MECE, pass as u32))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32,
+                total_passes: FIXED_PATTERNS.len() as u32,
+            }
+        );
     }
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -143,7 +160,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -159,7 +176,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -311,7 +329,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_mece::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -327,7 +346,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/gutmann.rs
+++ b/src/engine/overwrite/gutmann.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 // 3-byte fixed patterns (27 passes)
 const FIXED_PATTERNS: &[[u8; 3]] = &[
@@ -56,7 +57,7 @@ const FIXED_PATTERNS: &[[u8; 3]] = &[
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     // Total passes = 35
@@ -87,6 +88,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
         file.flush().map_err(|_| {
             Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
         })?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32+1,
+                total_passes: 35,
+            }
+        );
     }
 
     file.sync_all().map_err(|_| {
@@ -104,7 +113,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     // Total passes = 35
@@ -136,6 +145,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
             FSProblem::Write,
             format!("{}", path.to_string_lossy()),
         ))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: pass as u32+1,
+                total_passes: 35,
+            }
+        );
     }
 
     file.sync_all().change_context(Error::SystemProblem(
@@ -151,7 +168,6 @@ mod test {
     const METHOD_NAME: &str = "gutmann";
     use crate::Method::Gutmann as EraseMethod;
 
-    use super::overwrite_file;
     use crate::error::FSProblem;
     use crate::tests::TestType;
 
@@ -167,7 +183,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -183,7 +199,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -335,7 +352,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -351,7 +369,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/gutmann.rs
+++ b/src/engine/overwrite/gutmann.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 // 3-byte fixed patterns (27 passes)
 const FIXED_PATTERNS: &[[u8; 3]] = &[
@@ -57,7 +57,7 @@ const FIXED_PATTERNS: &[[u8; 3]] = &[
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     // Total passes = 35
@@ -92,9 +92,9 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             sink,
             DeleteEvent::EntryOverwritePass {
                 path: path.to_path_buf(),
-                pass: pass as u32+1,
+                pass: pass as u32 + 1,
                 total_passes: 35,
-            }
+            },
         );
     }
 
@@ -113,7 +113,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
 
     // Total passes = 35
@@ -149,9 +149,9 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             sink,
             DeleteEvent::EntryOverwritePass {
                 path: path.to_path_buf(),
-                pass: pass as u32+1,
+                pass: pass as u32 + 1,
                 total_passes: 35,
-            }
+            },
         );
     }
 
@@ -181,10 +181,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -200,7 +200,10 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(
+                    &path.to_path_buf(),
+                    &mut sink,
+                )?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -349,12 +352,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_me::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -370,7 +373,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/hmgi_s5.rs
+++ b/src/engine/overwrite/hmgi_s5.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -14,6 +14,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 /// Function that implement [HMGI S5 overwrite method](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
 /// ! Please note that this method does not delete the given file.
@@ -24,7 +25,7 @@ use log::info;
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..2 {
         file.seek(SeekFrom::Start(0))
@@ -41,6 +42,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::HmgiS5, &pattern + 1))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: &pattern + 1,
+                total_passes: 2,
+            }
+        );
     }
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -57,7 +66,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..2 {
         file.seek(SeekFrom::Start(0))
@@ -74,6 +83,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
         file.flush()
             .change_context(Error::OverwriteError(Method::HmgiS5, &pattern + 1))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: &pattern + 1,
+                total_passes: 2,
+            }
+        );
     }
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -88,7 +105,6 @@ mod test {
     const METHOD_NAME: &str = "hmgi_S5";
     use crate::Method::HmgiS5 as EraseMethod;
 
-    use super::overwrite_file;
     use crate::error::FSProblem;
     use crate::tests::TestType;
 
@@ -104,7 +120,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -120,7 +136,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -272,7 +289,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -288,7 +306,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/hmgi_s5.rs
+++ b/src/engine/overwrite/hmgi_s5.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -12,9 +12,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 /// Function that implement [HMGI S5 overwrite method](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
 /// ! Please note that this method does not delete the given file.
@@ -25,7 +25,7 @@ use crate::engine::utils::emit_safe;
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..2 {
         file.seek(SeekFrom::Start(0))
@@ -48,7 +48,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: &pattern + 1,
                 total_passes: 2,
-            }
+            },
         );
     }
     file.sync_all().map_err(|_| {
@@ -66,7 +66,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..2 {
         file.seek(SeekFrom::Start(0))
@@ -89,7 +89,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: &pattern + 1,
                 total_passes: 2,
-            }
+            },
         );
     }
     file.sync_all().change_context(Error::SystemProblem(
@@ -118,10 +118,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -137,7 +137,10 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(
+                    &path.to_path_buf(),
+                    &mut sink,
+                )?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -286,12 +289,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_me::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -307,7 +310,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/mod.rs
+++ b/src/engine/overwrite/mod.rs
@@ -8,7 +8,7 @@ mod hmgi_s5;
 mod pseudo_random;
 mod rcmp_tssit_ops_ii;
 
-use crate::Method;
+use crate::{EventSink, Method};
 use std::path::Path;
 
 #[cfg(not(feature = "error-stack"))]
@@ -20,29 +20,29 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(method: &Method, path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path)?,
-        Method::Afssi5020 => afssi_5020::overwrite_file(path)?,
-        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path)?,
-        Method::HmgiS5 => hmgi_s5::overwrite_file(path)?,
-        Method::Gutmann => gutmann::overwrite_file(path)?,
-        Method::PseudoRandom => pseudo_random::overwrite_file(path)?,
+        Method::Dod522022MECE => dod_522022_me::overwrite_file(path,sink)?,
+        Method::Dod522022ME => dod_522022_mece::overwrite_file(path,sink)?,
+        Method::Afssi5020 => afssi_5020::overwrite_file(path,sink)?,
+        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path,sink)?,
+        Method::HmgiS5 => hmgi_s5::overwrite_file(path,sink)?,
+        Method::Gutmann => gutmann::overwrite_file(path,sink)?,
+        Method::PseudoRandom => pseudo_random::overwrite_file(path,sink)?,
     };
     Ok(())
 }
 
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(method: &Method, path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path)?,
-        Method::Afssi5020 => afssi_5020::overwrite_file(path)?,
-        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path)?,
-        Method::HmgiS5 => hmgi_s5::overwrite_file(path)?,
-        Method::Gutmann => gutmann::overwrite_file(path)?,
-        Method::PseudoRandom => pseudo_random::overwrite_file(path)?,
+        Method::Dod522022MECE => dod_522022_me::overwrite_file(path,sink)?,
+        Method::Dod522022ME => dod_522022_mece::overwrite_file(path,sink)?,
+        Method::Afssi5020 => afssi_5020::overwrite_file(path,sink)?,
+        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path,sink)?,
+        Method::HmgiS5 => hmgi_s5::overwrite_file(path,sink)?,
+        Method::Gutmann => gutmann::overwrite_file(path,sink)?,
+        Method::PseudoRandom => pseudo_random::overwrite_file(path,sink)?,
     };
     Ok(())
 }

--- a/src/engine/overwrite/mod.rs
+++ b/src/engine/overwrite/mod.rs
@@ -20,29 +20,37 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(
+    method: &Method,
+    path: &Path,
+    sink: &mut S,
+) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path,sink)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path,sink)?,
-        Method::Afssi5020 => afssi_5020::overwrite_file(path,sink)?,
-        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path,sink)?,
-        Method::HmgiS5 => hmgi_s5::overwrite_file(path,sink)?,
-        Method::Gutmann => gutmann::overwrite_file(path,sink)?,
-        Method::PseudoRandom => pseudo_random::overwrite_file(path,sink)?,
+        Method::Dod522022MECE => dod_522022_me::overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Afssi5020 => afssi_5020::overwrite_file(path, sink)?,
+        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path, sink)?,
+        Method::HmgiS5 => hmgi_s5::overwrite_file(path, sink)?,
+        Method::Gutmann => gutmann::overwrite_file(path, sink)?,
+        Method::PseudoRandom => pseudo_random::overwrite_file(path, sink)?,
     };
     Ok(())
 }
 
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(method: &Method, path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(
+    method: &Method,
+    path: &Path,
+    sink: &mut S,
+) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path,sink)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path,sink)?,
-        Method::Afssi5020 => afssi_5020::overwrite_file(path,sink)?,
-        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path,sink)?,
-        Method::HmgiS5 => hmgi_s5::overwrite_file(path,sink)?,
-        Method::Gutmann => gutmann::overwrite_file(path,sink)?,
-        Method::PseudoRandom => pseudo_random::overwrite_file(path,sink)?,
+        Method::Dod522022MECE => dod_522022_me::overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Afssi5020 => afssi_5020::overwrite_file(path, sink)?,
+        Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path, sink)?,
+        Method::HmgiS5 => hmgi_s5::overwrite_file(path, sink)?,
+        Method::Gutmann => gutmann::overwrite_file(path, sink)?,
+        Method::PseudoRandom => pseudo_random::overwrite_file(path, sink)?,
     };
     Ok(())
 }

--- a/src/engine/overwrite/pseudo_random.rs
+++ b/src/engine/overwrite/pseudo_random.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::Write;
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 /// Function that implement a basic pseudo random method using basic error handling method.
 /// ! Please note that this method does not delete the given file.
@@ -26,7 +26,7 @@ use crate::engine::utils::emit_safe;
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
     let computed_md5 = md5::compute(format!("{}", path.to_string_lossy()));
 
@@ -59,7 +59,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             path: path.to_path_buf(),
             pass: 1,
             total_passes: 1,
-        }
+        },
     );
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -77,7 +77,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
     let computed_md5 = md5::compute(format!("{}", path.to_string_lossy()));
 
@@ -110,7 +110,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             path: path.to_path_buf(),
             pass: 1,
             total_passes: 1,
-        }
+        },
     );
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -139,10 +139,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -158,7 +158,10 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(
+                    &path.to_path_buf(),
+                    &mut sink,
+                )?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -307,12 +310,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_me::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -328,7 +331,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/pseudo_random.rs
+++ b/src/engine/overwrite/pseudo_random.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::Write;
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 /// Function that implement a basic pseudo random method using basic error handling method.
 /// ! Please note that this method does not delete the given file.
@@ -25,7 +26,7 @@ use log::info;
 /// ## Return
 /// * `()`
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
     let computed_md5 = md5::compute(format!("{}", path.to_string_lossy()));
 
@@ -52,6 +53,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
     file.flush()
         .map_err(|_| Error::OverwriteError(Method::PseudoRandom, 1))?;
+    emit_safe(
+        sink,
+        DeleteEvent::EntryOverwritePass {
+            path: path.to_path_buf(),
+            pass: 1,
+            total_passes: 1,
+        }
+    );
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
     })?;
@@ -68,7 +77,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()`
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
     let computed_md5 = md5::compute(format!("{}", path.to_string_lossy()));
 
@@ -95,6 +104,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
     file.flush()
         .change_context(Error::OverwriteError(Method::PseudoRandom, 1))?;
+    emit_safe(
+        sink,
+        DeleteEvent::EntryOverwritePass {
+            path: path.to_path_buf(),
+            pass: 1,
+            total_passes: 1,
+        }
+    );
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
         format!("{}", path.to_string_lossy()),
@@ -109,7 +126,6 @@ mod test {
     const METHOD_NAME: &str = "pseudo_random";
     use crate::Method::PseudoRandom as EraseMethod;
 
-    use super::overwrite_file;
     use crate::error::FSProblem;
     use crate::tests::TestType;
 
@@ -125,7 +141,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -141,7 +157,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -293,7 +310,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -309,7 +327,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/rcmp_tssit_ops_ii.rs
+++ b/src/engine/overwrite/rcmp_tssit_ops_ii.rs
@@ -1,5 +1,5 @@
-use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
+use crate::{DeleteEvent, EventSink, Method};
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
@@ -13,9 +13,9 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
+use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
-use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 
@@ -28,7 +28,7 @@ const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 /// ## Return
 /// * `()
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..6 {
         // rewind start of file
@@ -53,7 +53,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: &pattern + 1,
                 total_passes: 7,
-            }
+            },
         );
     }
     let mut remaining = file_size;
@@ -76,7 +76,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             path: path.to_path_buf(),
             pass: 7,
             total_passes: 7,
-        }
+        },
     );
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
@@ -94,7 +94,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
 /// ## Return
 /// * `()
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
+pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..6 {
         // rewind start of filels
@@ -119,7 +119,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
                 path: path.to_path_buf(),
                 pass: &pattern + 1,
                 total_passes: 7,
-            }
+            },
         );
     }
     let mut remaining = file_size;
@@ -142,7 +142,7 @@ pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result
             path: path.to_path_buf(),
             pass: 7,
             total_passes: 7,
-        }
+        },
     );
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
@@ -171,10 +171,10 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -190,7 +190,10 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(
+                    &path.to_path_buf(),
+                    &mut sink,
+                )?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -339,12 +342,12 @@ mod test {
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
+            use super::*;
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-            use crate::api::delete::request::NoopSink;
-            use crate::engine::overwrite::dod_522022_me::overwrite_file;
-            use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -360,7 +363,7 @@ mod test {
                 let path = Path::new(&string_path);
                 assert!(path.exists());
                 let mut sink = NoopSink;
-                overwrite_file(&path.to_path_buf(),&mut sink)?;
+                overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/overwrite/rcmp_tssit_ops_ii.rs
+++ b/src/engine/overwrite/rcmp_tssit_ops_ii.rs
@@ -1,4 +1,4 @@
-use crate::Method;
+use crate::{DeleteEvent, EventSink, Method};
 use crate::engine::overwrite::common::prepare_overwrite;
 use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
@@ -15,6 +15,7 @@ use error_stack::ResultExt;
 
 #[cfg(feature = "log")]
 use log::info;
+use crate::engine::utils::emit_safe;
 
 const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 
@@ -27,7 +28,7 @@ const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 /// ## Return
 /// * `()
 #[cfg(not(feature = "error-stack"))]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..6 {
         // rewind start of file
@@ -46,6 +47,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
         // flush after each pass (best-effort)
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::RcmpTssitOpsII, &pattern + 1))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: &pattern + 1,
+                total_passes: 7,
+            }
+        );
     }
     let mut remaining = file_size;
     file.seek(SeekFrom::Start(0))
@@ -61,6 +70,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
     file.flush()
         .map_err(|_| Error::OverwriteError(Method::RcmpTssitOpsII, 7))?;
+    emit_safe(
+        sink,
+        DeleteEvent::EntryOverwritePass {
+            path: path.to_path_buf(),
+            pass: 7,
+            total_passes: 7,
+        }
+    );
     file.sync_all().map_err(|_| {
         Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
     })?;
@@ -77,7 +94,7 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 /// ## Return
 /// * `()
 #[cfg(feature = "error-stack")]
-pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
+pub(crate) fn overwrite_file<S : EventSink>(path: &Path,sink : &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
     for pattern in 0..6 {
         // rewind start of filels
@@ -96,6 +113,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
         // flush after each pass (best-effort)
         file.flush()
             .change_context(Error::OverwriteError(Method::RcmpTssitOpsII, &pattern + 1))?;
+        emit_safe(
+            sink,
+            DeleteEvent::EntryOverwritePass {
+                path: path.to_path_buf(),
+                pass: &pattern + 1,
+                total_passes: 7,
+            }
+        );
     }
     let mut remaining = file_size;
     file.seek(SeekFrom::Start(0))
@@ -111,6 +136,14 @@ pub(crate) fn overwrite_file(path: &Path) -> Result<()> {
 
     file.flush()
         .change_context(Error::OverwriteError(Method::RcmpTssitOpsII, 7))?;
+    emit_safe(
+        sink,
+        DeleteEvent::EntryOverwritePass {
+            path: path.to_path_buf(),
+            pass: 7,
+            total_passes: 7,
+        }
+    );
     file.sync_all().change_context(Error::SystemProblem(
         FSProblem::Write,
         format!("{}", path.to_string_lossy()),
@@ -125,7 +158,6 @@ mod test {
     const METHOD_NAME: &str = "rcmp_tssit_ops_ii";
     use crate::Method::RcmpTssitOpsII as EraseMethod;
 
-    use super::overwrite_file;
     use crate::error::FSProblem;
     use crate::tests::TestType;
 
@@ -141,7 +173,7 @@ mod test {
         mod no_log {
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -157,7 +189,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                crate::engine::overwrite::dod_522022_me::overwrite_file(&path.to_path_buf(), &mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());
@@ -309,7 +342,8 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
-
+            use crate::api::delete::request::NoopSink;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
             use super::*;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
@@ -325,7 +359,8 @@ mod test {
                     create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
                 let path = Path::new(&string_path);
                 assert!(path.exists());
-                overwrite_file(&path.to_path_buf())?;
+                let mut sink = NoopSink;
+                overwrite_file(&path.to_path_buf(),&mut sink)?;
                 let bytes = get_bytes(&path)?;
                 assert_eq!(bytes.len(), lorem.as_bytes().len());
                 assert_ne!(bytes, lorem.as_bytes());

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -7,8 +7,9 @@
 use crate::{Error, Result};
 use std::fs;
 use std::path::Path;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::SecureDelete;
+use crate::{DeleteEvent, EventSink, SecureDelete};
 use crate::error::FSProblem;
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
@@ -66,6 +67,12 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
             format!("{}", &new_path.to_string_lossy()),
         )
     })
+}
+
+pub(super) fn emit_safe<S: EventSink>(sink: &mut S, event: DeleteEvent) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        sink.emit(event);
+    }));
 }
 
 #[cfg(not(feature = "error-stack"))]

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -6,11 +6,11 @@
 #[cfg(not(feature = "error-stack"))]
 use crate::{Error, Result};
 use std::fs;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
-use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::{DeleteEvent, EventSink, SecureDelete};
 use crate::error::FSProblem;
+use crate::{DeleteEvent, EventSink, SecureDelete};
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
 #[cfg(feature = "error-stack")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub use api::delete::DeleteReport;
 pub use api::delete::DeleteRequest;
 pub use api::delete::DeleteRequestBuilder;
 
+pub use engine::events::{DeleteEvent, EventSink};
+
 // -- Export object
 pub use crate::methods::Method;
 pub use crate::models::SecureDelete;

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 // -- Region : feature import
 #[cfg(not(feature = "error-stack"))]
 use crate::Result;
-
+use crate::api::delete::request::NoopSink;
 #[cfg(feature = "log")]
 use log::{error, info, warn};
 
@@ -47,7 +47,8 @@ impl Method {
     /// * `path` (&str) : path that you want to erase using the given overwrite method
     pub fn delete(&self, path: &str) -> Result<()> {
         let path_to_delete = Path::new(path);
-        run(self, path_to_delete)
+        let mut sink = NoopSink;
+        run(self, path_to_delete,&mut sink)
     }
 }
 
@@ -61,7 +62,8 @@ impl Method {
     /// * `path` (&str) : path that you want to erase using the given overwrite method
     pub fn delete(&self, path: &str) -> Result<()> {
         let path_to_delete = Path::new(path);
-        run(self, path_to_delete)
+        let mut sink = NoopSink;
+        run(self, path_to_delete, &mut sink)
     }
 }
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -48,7 +48,7 @@ impl Method {
     pub fn delete(&self, path: &str) -> Result<()> {
         let path_to_delete = Path::new(path);
         let mut sink = NoopSink;
-        run(self, path_to_delete,&mut sink)
+        run(self, path_to_delete, &mut sink)
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -106,15 +106,13 @@ impl SecureDelete {
     /// * `buffer` (Vec \<u8\>) : a buffer of hexadecimal data
     fn get_buffer(&self, size: usize) -> Vec<u8> {
         let mut buffer = Vec::<u8>::new();
-        if self.byte.is_some() {
-            let byte = &self.byte.unwrap();
+        if let Some(byte) = &self.byte {
             for _ in 0..size {
                 buffer.push(*byte);
             }
             return buffer;
         }
-        if self.pattern.is_some() {
-            let bytes_pattern = &self.pattern.unwrap();
+        if let Some(bytes_pattern) = self.pattern {
             for i in 0..size {
                 let pattern_index = i % 3;
                 buffer.push(bytes_pattern[pattern_index]);

--- a/tests/events/emission_order.rs
+++ b/tests/events/emission_order.rs
@@ -1,7 +1,7 @@
 use nozomi::*;
 
-use crate::events::temp_test_file;
 use crate::events::MockSink;
+use crate::events::temp_test_file;
 use pretty_assertions::assert_eq;
 
 #[cfg(not(feature = "error-stack"))]
@@ -10,32 +10,32 @@ use nozomi::Result;
 #[test]
 #[cfg(not(feature = "error-stack"))]
 fn events_are_emitted_in_deterministic_order() -> Result<()> {
-	let path = temp_test_file("order");
+    let path = temp_test_file("order");
 
-	let mut sink = MockSink::default();
+    let mut sink = MockSink::default();
 
-	let request = DeleteRequest::builder()
-		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
-		.path(&path)
-		.build()?;
+    let request = DeleteRequest::builder()
+        .method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+        .path(&path)
+        .build()?;
 
-	request.run_with(&mut sink)?;
+    request.run_with(&mut sink)?;
 
-	assert_eq!(
-		sink.events,
-		vec![
-			DeleteEvent::DeletionStarted { path: path.clone() },
-			DeleteEvent::EntryOverwritePass{
-				path: path.clone(),
-				pass: 1,
-				total_passes: 1,
-			},
-			DeleteEvent::EntryDeleted { path: path.clone() },
-			DeleteEvent::DeletionFinished { path },
-		]
-	);
+    assert_eq!(
+        sink.events,
+        vec![
+            DeleteEvent::DeletionStarted { path: path.clone() },
+            DeleteEvent::EntryOverwritePass {
+                path: path.clone(),
+                pass: 1,
+                total_passes: 1,
+            },
+            DeleteEvent::EntryDeleted { path: path.clone() },
+            DeleteEvent::DeletionFinished { path },
+        ]
+    );
 
-	Ok(())
+    Ok(())
 }
 
 #[cfg(feature = "error-stack")]
@@ -44,31 +44,30 @@ use nozomi::Result;
 #[test]
 #[cfg(feature = "error-stack")]
 fn events_are_emitted_in_deterministic_order() -> Result<()> {
-	let path = temp_test_file("order");
+    let path = temp_test_file("order");
 
-	let mut sink = MockSink::default();
+    let mut sink = MockSink::default();
 
-	let request = DeleteRequest::builder()
-		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+    let request = DeleteRequest::builder()
+        .method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+        .path(&path)
+        .build()?;
 
-		.path(&path)
-		.build()?;
+    request.run_with(&mut sink)?;
 
-	request.run_with(&mut sink)?;
+    assert_eq!(
+        sink.events,
+        vec![
+            DeleteEvent::DeletionStarted { path: path.clone() },
+            DeleteEvent::EntryOverwritePass {
+                path: path.clone(),
+                pass: 1,
+                total_passes: 1,
+            },
+            DeleteEvent::EntryDeleted { path: path.clone() },
+            DeleteEvent::DeletionFinished { path },
+        ]
+    );
 
-	assert_eq!(
-		sink.events,
-		vec![
-			DeleteEvent::DeletionStarted { path: path.clone() },
-			DeleteEvent::EntryOverwritePass{
-				path: path.clone(),
-				pass: 1,
-				total_passes: 1,
-			},
-			DeleteEvent::EntryDeleted { path: path.clone() },
-			DeleteEvent::DeletionFinished { path },
-		]
-	);
-
-	Ok(())
+    Ok(())
 }

--- a/tests/events/emission_order.rs
+++ b/tests/events/emission_order.rs
@@ -1,0 +1,74 @@
+use nozomi::*;
+
+use crate::events::temp_test_file;
+use crate::events::MockSink;
+use pretty_assertions::assert_eq;
+
+#[cfg(not(feature = "error-stack"))]
+use nozomi::Result;
+
+#[test]
+#[cfg(not(feature = "error-stack"))]
+fn events_are_emitted_in_deterministic_order() -> Result<()> {
+	let path = temp_test_file("order");
+
+	let mut sink = MockSink::default();
+
+	let request = DeleteRequest::builder()
+		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+		.path(&path)
+		.build()?;
+
+	request.run_with(&mut sink)?;
+
+	assert_eq!(
+		sink.events,
+		vec![
+			DeleteEvent::DeletionStarted { path: path.clone() },
+			DeleteEvent::EntryOverwritePass{
+				path: path.clone(),
+				pass: 1,
+				total_passes: 1,
+			},
+			DeleteEvent::EntryDeleted { path: path.clone() },
+			DeleteEvent::DeletionFinished { path },
+		]
+	);
+
+	Ok(())
+}
+
+#[cfg(feature = "error-stack")]
+use nozomi::Result;
+
+#[test]
+#[cfg(feature = "error-stack")]
+fn events_are_emitted_in_deterministic_order() -> Result<()> {
+	let path = temp_test_file("order");
+
+	let mut sink = MockSink::default();
+
+	let request = DeleteRequest::builder()
+		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+
+		.path(&path)
+		.build()?;
+
+	request.run_with(&mut sink)?;
+
+	assert_eq!(
+		sink.events,
+		vec![
+			DeleteEvent::DeletionStarted { path: path.clone() },
+			DeleteEvent::EntryOverwritePass{
+				path: path.clone(),
+				pass: 1,
+				total_passes: 1,
+			},
+			DeleteEvent::EntryDeleted { path: path.clone() },
+			DeleteEvent::DeletionFinished { path },
+		]
+	);
+
+	Ok(())
+}

--- a/tests/events/error_behavior.rs
+++ b/tests/events/error_behavior.rs
@@ -6,25 +6,25 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn deletion_finished_is_emitted_even_on_error() {
-	let path = PathBuf::from("this_file_should_not_exist");
+    let path = PathBuf::from("this_file_should_not_exist");
 
-	let mut sink = MockSink::default();
+    let mut sink = MockSink::default();
 
-	let request = DeleteRequest::builder()
-		.path(&path)
-		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
-		.build()
-		.expect("builder should succeed");
+    let request = DeleteRequest::builder()
+        .path(&path)
+        .method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+        .build()
+        .expect("builder should succeed");
 
-	let result = request.run_with(&mut sink);
+    let result = request.run_with(&mut sink);
 
-	assert!(result.is_err());
+    assert!(result.is_err());
 
-	assert_eq!(
-		sink.events,
-		vec![
-			DeleteEvent::DeletionStarted { path: path.clone() },
-			DeleteEvent::DeletionFinished { path },
-		]
-	);
+    assert_eq!(
+        sink.events,
+        vec![
+            DeleteEvent::DeletionStarted { path: path.clone() },
+            DeleteEvent::DeletionFinished { path },
+        ]
+    );
 }

--- a/tests/events/error_behavior.rs
+++ b/tests/events/error_behavior.rs
@@ -1,0 +1,30 @@
+use nozomi::*;
+use std::path::PathBuf;
+
+use crate::events::MockSink;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn deletion_finished_is_emitted_even_on_error() {
+	let path = PathBuf::from("this_file_should_not_exist");
+
+	let mut sink = MockSink::default();
+
+	let request = DeleteRequest::builder()
+		.path(&path)
+		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+		.build()
+		.expect("builder should succeed");
+
+	let result = request.run_with(&mut sink);
+
+	assert!(result.is_err());
+
+	assert_eq!(
+		sink.events,
+		vec![
+			DeleteEvent::DeletionStarted { path: path.clone() },
+			DeleteEvent::DeletionFinished { path },
+		]
+	);
+}

--- a/tests/events/mod.rs
+++ b/tests/events/mod.rs
@@ -5,19 +5,19 @@ mod sink_isolation;
 
 use nozomi::{DeleteEvent, EventSink};
 pub fn temp_test_file(name: &str) -> PathBuf {
-	let mut path = std::env::temp_dir();
-	path.push(format!("nozomi_test_{name}"));
-	std::fs::write(&path, b"test-data").expect("failed to create test file");
-	path
+    let mut path = std::env::temp_dir();
+    path.push(format!("nozomi_test_{name}"));
+    std::fs::write(&path, b"test-data").expect("failed to create test file");
+    path
 }
 
 #[derive(Default)]
 pub struct MockSink {
-	pub events: Vec<DeleteEvent>,
+    pub events: Vec<DeleteEvent>,
 }
 
 impl EventSink for MockSink {
-	fn emit(&mut self, event: DeleteEvent) {
-		self.events.push(event);
-	}
+    fn emit(&mut self, event: DeleteEvent) {
+        self.events.push(event);
+    }
 }

--- a/tests/events/mod.rs
+++ b/tests/events/mod.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+mod emission_order;
+mod error_behavior;
+mod sink_isolation;
+
+use nozomi::{DeleteEvent, EventSink};
+pub fn temp_test_file(name: &str) -> PathBuf {
+	let mut path = std::env::temp_dir();
+	path.push(format!("nozomi_test_{name}"));
+	std::fs::write(&path, b"test-data").expect("failed to create test file");
+	path
+}
+
+#[derive(Default)]
+pub struct MockSink {
+	pub events: Vec<DeleteEvent>,
+}
+
+impl EventSink for MockSink {
+	fn emit(&mut self, event: DeleteEvent) {
+		self.events.push(event);
+	}
+}

--- a/tests/events/sink_isolation.rs
+++ b/tests/events/sink_isolation.rs
@@ -1,0 +1,60 @@
+use nozomi::*;
+
+#[cfg(not(feature = "error-stack"))]
+use nozomi::Result;
+
+#[cfg(feature = "error-stack")]
+use nozomi::Result;
+
+use crate::events::temp_test_file;
+
+struct PanicSink;
+
+impl EventSink for PanicSink {
+	fn emit(&mut self, _: DeleteEvent) {
+		panic!("sink panic");
+	}
+}
+
+
+
+#[test]
+#[cfg(not(feature = "error-stack"))]
+fn sink_panic_does_not_abort_deletion() -> Result<()> {
+	let path = temp_test_file("panic_sink");
+
+	let mut sink = PanicSink;
+
+	let request = DeleteRequest::builder()
+		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+		.path(&path)
+		.build()?;
+
+	// Should not panic even if sink panics internally
+	let result = request.run_with(&mut sink);
+
+	assert!(result.is_ok());
+
+	Ok(())
+}
+
+
+#[test]
+#[cfg(feature = "error-stack")]
+fn sink_panic_does_not_abort_deletion() -> Result<()> {
+	let path = temp_test_file("panic_sink");
+
+	let mut sink = PanicSink;
+
+	let request = DeleteRequest::builder()
+		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+		.path(&path)
+		.build()?;
+
+	// Should not panic even if sink panics internally
+	let result = request.run_with(&mut sink);
+
+	assert!(result.is_ok());
+
+	Ok(())
+}

--- a/tests/events/sink_isolation.rs
+++ b/tests/events/sink_isolation.rs
@@ -11,50 +11,47 @@ use crate::events::temp_test_file;
 struct PanicSink;
 
 impl EventSink for PanicSink {
-	fn emit(&mut self, _: DeleteEvent) {
-		panic!("sink panic");
-	}
+    fn emit(&mut self, _: DeleteEvent) {
+        panic!("sink panic");
+    }
 }
-
-
 
 #[test]
 #[cfg(not(feature = "error-stack"))]
 fn sink_panic_does_not_abort_deletion() -> Result<()> {
-	let path = temp_test_file("panic_sink");
+    let path = temp_test_file("panic_sink");
 
-	let mut sink = PanicSink;
+    let mut sink = PanicSink;
 
-	let request = DeleteRequest::builder()
-		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
-		.path(&path)
-		.build()?;
+    let request = DeleteRequest::builder()
+        .method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+        .path(&path)
+        .build()?;
 
-	// Should not panic even if sink panics internally
-	let result = request.run_with(&mut sink);
+    // Should not panic even if sink panics internally
+    let result = request.run_with(&mut sink);
 
-	assert!(result.is_ok());
+    assert!(result.is_ok());
 
-	Ok(())
+    Ok(())
 }
-
 
 #[test]
 #[cfg(feature = "error-stack")]
 fn sink_panic_does_not_abort_deletion() -> Result<()> {
-	let path = temp_test_file("panic_sink");
+    let path = temp_test_file("panic_sink");
 
-	let mut sink = PanicSink;
+    let mut sink = PanicSink;
 
-	let request = DeleteRequest::builder()
-		.method(DeleteMethod::BuiltIn(Method::PseudoRandom))
-		.path(&path)
-		.build()?;
+    let request = DeleteRequest::builder()
+        .method(DeleteMethod::BuiltIn(Method::PseudoRandom))
+        .path(&path)
+        .build()?;
 
-	// Should not panic even if sink panics internally
-	let result = request.run_with(&mut sink);
+    // Should not panic even if sink panics internally
+    let result = request.run_with(&mut sink);
 
-	assert!(result.is_ok());
+    assert!(result.is_ok());
 
-	Ok(())
+    Ok(())
 }

--- a/tests/test_export.rs
+++ b/tests/test_export.rs
@@ -1,3 +1,5 @@
+mod events;
+
 #[cfg(test)]
 #[cfg_attr(test, allow(unused_imports, path_statements))]
 #[test]


### PR DESCRIPTION
## 🚀 What's New

This PR introduces a structured event-driven execution model for
deletion operations.

New public components:

-   `DeleteEvent`
-   `EventSink`
-   `DeleteRequest::run_with`

The existing `run()` method remains unchanged and internally delegates to `run_with` using a `NoopSink`.

Deletion execution can now be observed in a deterministic and non-intrusive way.

## ♻️ Legacy Compatibility

-   No changes to the existing `run()` signature
-   No changes to error semantics
-   No behavioral differences in default execution
-   All legacy flows remain intact

The event system is fully additive and does not interfere with historical deletion logic.

## 🔧 Internal Changes

-   `engine::run` now accepts a generic `EventSink`
-   Introduced internal `emit_safe` helper using `catch_unwind`
-   Ensured `DeletionFinished` is always emitted (even on error)
-   Overwrite operations emit one `EntryOverwritePass` per pass
-   Event emission order is strictly deterministic
-   Default execution path uses an internal `NoopSink`

### Event ordering

Single file:
```
    DeletionStarted
    EntryOverwritePass (n times)
    EntryDeleted
    DeletionFinished
```

Multiple entries:

```
    DeletionStarted
    (file A passes...)
    EntryDeleted A
    (file B passes...)
    EntryDeleted B
    DeletionFinished
```
## 🧩 API Design Notes

### `DeleteEvent`

``` rust
pub enum DeleteEvent {
    DeletionStarted { path: PathBuf },
    EntryOverwritePass { path: PathBuf, pass: u32, total_passes: u32 },
    EntryDeleted { path: PathBuf },
    DeletionFinished { path: PathBuf },
}
```

### `EventSink`

``` rust
pub trait EventSink {
    fn emit(&mut self, event: DeleteEvent);
}
```

### Execution

``` rust
pub fn run_with<S: EventSink>(
    &self,
    sink: &mut S,
) -> Result<DeleteReport>
```

### Design principles:

-   Events are purely informational
-   Events never influence control flow
-   Errors continue to be returned exclusively via `Result`
-   Sink panics are isolated via `catch_unwind`
-   No additional metadata is exposed beyond file paths and overwrite progress


## ✅ Compatibility & Status

-   Fully additive change
-   No breaking changes
-   All integration tests pass
-   Default behavior unchanged
-   Compatible with existing features (`error-stack`, etc.)

## Follow-ups

-   Optional feature-gated logging sink
-   CLI integration consuming `DeleteEvent`
