### PR TITLE
release: prepare v3.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,84 +1,155 @@
 name: Bug report
-description: Declare a bug inside the library
-title: '[BUG]: '
+description: Report unexpected behavior in the library
+title: "[BUG]: "
 labels:
-  - Bug
+  - bug
 body:
   - type: checkboxes
-    id: version_selector
+    id: preflight
     attributes:
-      label: For which version of the library would you like to report a bug?
-      description: To date, only versions 2.x and 3.x are officially supported.
+      label: Pre-flight checklist
       options:
-        - label: 3.0.0
-          required: false
-        - label: 2.0.1
-          required: false
-        - label: 2.0.0
-          required: false
-        - label: 1.0.2
-          required: false
-        - label: 1.0.1
-          required: false
-        - label: 1.0.0
-          required: false
-  - type: checkboxes
-    id: activated_feature
-    attributes:
-      label: Which features did you use?
-      options:
-        - label: unknown
-          required: false
-        - label: error_stack
-          required: false
-        - label: log
-          required: false
-        - label: secure_log
-          required: false
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I am using a supported version (2.x or 3.x)
+          required: true
+
   - type: dropdown
-    id: erasing_method
+    id: version
     attributes:
-      label: Did you erase a folder or a file ?
+      label: Library version
+      description: Which version of Nozomi are you using?
       options:
-        - Files
-        - Folder
+        - "3.x (current stable)"
+        - "2.x (LTS)"
+        - "1.x (unsupported — best effort)"
+        - "Other / pre-release"
     validations:
       required: true
+
+  - type: checkboxes
+    id: features
+    attributes:
+      label: Cargo features enabled
+      description: Which features did you enable in `Cargo.toml`?
+      options:
+        - label: "`dry-run`"
+        - label: "`verify`"
+        - label: "`analyze`"
+        - label: "`log`"
+        - label: "`secure_log`"
+        - label: "`error-stack`"
+        - label: None (default build)
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Overwrite method used
+      options:
+        - PseudoRandom (default)
+        - Gutmann (35 passes)
+        - DoD 5220.22-M ECE (7 passes)
+        - DoD 5220.22-M ME (3 passes)
+        - AFSSI 5020 (3 passes)
+        - RCMP TSSIT OPS-II (7 passes)
+        - HMGI S5 (2 passes)
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target_type
+    attributes:
+      label: Deletion target
+      options:
+        - File
+        - Directory
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Arch Linux 6.12, Ubuntu 24.04, macOS 14.5, Windows 11"
+    validations:
+      required: true
+
   - type: input
     id: drive_type
     attributes:
-      label: Hard disk type
-      placeholder: SSD \ HDD
+      label: Storage type
+      placeholder: "SSD / HDD / NVMe / RAM disk / network share"
     validations:
       required: true
-  - type: input
-    id: os_version_type
-    attributes:
-      label: On which systems did you encounter the bug?
-      placeholder: Arch Linux 6.x
-    validations:
-      required: true
+
   - type: input
     id: file_type
     attributes:
-      label: Type of file you tried to delete
-      placeholder: mp4
+      label: File type
+      placeholder: "e.g. mp4, sqlite, txt"
     validations:
       required: true
+
   - type: input
     id: file_size
     attributes:
-      label: Size of file you tried to delete
-      placeholder: 32Go
+      label: File size
+      placeholder: "e.g. 4 KB, 2 GB"
     validations:
       required: true
+
   - type: textarea
-    id: other_file_metadata
+    id: expected
     attributes:
-      label: Write here all the metadata that might be relevant to your case
-  - type: textarea
-    id: bug_step
-    attributes:
-      label: Explain the different steps that could help us reproduce the bug
+      label: Expected behavior
+      description: What did you expect to happen?
     validations:
       required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error message / stack trace
+      description: Paste the full error output if any.
+      render: text
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, numbered steps to trigger the bug.
+      placeholder: |
+        1. Create a file with ...
+        2. Call `Method::Gutmann.delete(...)` with ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: snippet
+    attributes:
+      label: Minimal reproducible example
+      description: A short Rust snippet that demonstrates the issue.
+      render: rust
+      placeholder: |
+        use nozomi::{Method, DeleteRequest};
+
+        fn main() {
+            // ...
+        }
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Filesystem permissions, unusual mount options, concurrent access, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Sans-Atout/Nozomi/security/advisories/new
+    about: Report vulnerabilities privately via GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: Suggest an improvement or new capability for the library
+title: "[FEATURE]: "
+labels:
+  - enhancement
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and this has not been requested before
+          required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type of request
+      options:
+        - New overwrite method / algorithm
+        - New Cargo feature flag
+        - API improvement (builder, events, report)
+        - Performance improvement
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What limitation or missing capability is this request addressing?
+      placeholder: "When I try to … I cannot … because …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or API you would like to see.
+      placeholder: |
+        Add a `Method::Xyz` variant that …
+
+        ```rust
+        // Proposed usage
+        DeleteRequest::builder("path/to/file")
+            .method(Method::Xyz)
+            .execute()?;
+        ```
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have thought about, and why they fall short.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request for this feature

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Cargo — current active major (main = 3.x)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "cargo"
+
+  # Cargo — LTS branches (duplicate and uncomment when a new major is released)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    target-branch: "v2.x"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "cargo"
+
+  # GitHub Actions — current active branch only
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,89 @@
+# Pull Request
+
+Closes #
+
+---
+
+## 🏷️ Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor (no behavior change)
+- [ ] Documentation
+- [ ] Dependency update
+
+---
+
+## 📝 Description
+
+<!-- What problem does this PR solve? Why this approach? -->
+
+### Changes
+
+- 
+- 
+
+---
+
+## 🔒 Security Considerations
+
+Secure deletion is a sensitive operation. Confirm:
+
+- [ ] No data loss risk introduced
+- [ ] No panic on user input
+- [ ] File operations remain deterministic
+
+<!-- Explain any security implications if applicable. -->
+
+---
+
+## 🚀 API Impact
+
+- [ ] No API change
+- [ ] Backward compatible change
+- [ ] Breaking change — migration notes below
+
+<details>
+<summary>Migration notes (breaking change only)</summary>
+
+<!-- Describe what breaks and how to migrate. Update MIGRATION.md accordingly. -->
+
+```rust
+// Before
+
+// After
+```
+
+</details>
+
+---
+
+## ⚙️ Components affected
+
+- [ ] API / Builder
+- [ ] Engine (Planner / Executor)
+- [ ] Overwrite algorithms
+- [ ] Events / Report
+- [ ] Error handling
+- [ ] CI / Tooling
+
+---
+
+## 🧪 Testing
+
+- [ ] Unit tests added / updated
+- [ ] Integration tests updated
+- [ ] Edge cases covered
+- [ ] All existing tests pass (`cargo test`)
+
+<!-- How should the reviewer test this? -->
+
+---
+
+## ✅ Checklist
+
+- [ ] `cargo fmt` clean
+- [ ] `cargo clippy` clean
+- [ ] Public API documented
+- [ ] CHANGELOG / MIGRATION.md updated if needed

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,25 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,231 @@
+name: Publish
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - '[0-9]+.x'
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1 — Prepare the release (runs automatically after Dependabot merge)
+  # Bumps the patch version, generates the CHANGELOG entry, and uploads the
+  # modified files as an artifact for the publish job to consume.
+  # ---------------------------------------------------------------------------
+  prepare:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'cargo')
+
+    outputs:
+      new_version:      ${{ steps.bump.outputs.new_version }}
+      current_major:    ${{ steps.bump.outputs.current_major }}
+      is_highest_major: ${{ steps.highest.outputs.is_highest_major }}
+      higher_branches:  ${{ steps.highest.outputs.higher_branches }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          python3 - <<'PYEOF'
+          import re, os
+          content = open('Cargo.toml').read()
+          m = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"', content, re.M)
+          major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+          new_ver = f'{major}.{minor}.{patch + 1}'
+          open('Cargo.toml', 'w').write(content.replace(m.group(0), f'version = "{new_ver}"', 1))
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'new_version={new_ver}\n')
+              fh.write(f'current_major={major}\n')
+          PYEOF
+
+      # Determine which N.x branches exist and whether we are the highest.
+      # Result: is_highest_major = true/false
+      #         higher_branches  = comma-separated list of branches above us (may be empty)
+      - name: Detect highest major branch
+        id: highest
+        run: |
+          git fetch --all --quiet
+          CUR="${{ steps.bump.outputs.current_major }}"
+          HIGHEST=$(git branch -r | grep -oP '(?<=origin/)\d+(?=\.x$)' | sort -n | tail -1)
+          HIGHER=$(git branch -r \
+            | grep -oP '(?<=origin/)\d+(?=\.x$)' \
+            | awk -v c="$CUR" 'int($0) > int(c)' \
+            | sort -n \
+            | sed 's/$/.x/' \
+            | tr '\n' ',' \
+            | sed 's/,$//')
+          if [ -z "$HIGHEST" ] || [ "$CUR" = "$HIGHEST" ]; then
+            echo "is_highest_major=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "is_highest_major=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "higher_branches=$HIGHER" >> "$GITHUB_OUTPUT"
+
+      # Build the CHANGELOG entry with Python string concatenation so that no
+      # zero-indented lines appear inside the YAML block scalar (which would
+      # terminate it prematurely and break the workflow).
+      - name: Update CHANGELOG.md
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          DEP_NAME:    ${{ steps.metadata.outputs.dependency-names }}
+          DEP_FROM:    ${{ steps.metadata.outputs.previous-version }}
+          DEP_TO:      ${{ steps.metadata.outputs.new-version }}
+        run: |
+          python3 - <<'PYEOF'
+          import os
+          new_version = os.environ['NEW_VERSION']
+          dep_name    = os.environ['DEP_NAME']
+          dep_from    = os.environ['DEP_FROM']
+          dep_to      = os.environ['DEP_TO']
+          fence = '`' * 3
+          entry = (
+              f"## [v{new_version}](https://crates.io/crates/nozomi/{new_version})\n\n"
+              + fence + "diff\n"
+              + "Project change :\n"
+              + f"! {dep_name} : {dep_from} --> {dep_to}\n"
+              + fence + "\n\n"
+          )
+          content = open('CHANGELOG.md').read()
+          open('CHANGELOG.md', 'w').write(
+              content.replace('# Changelog\n\n', '# Changelog\n\n' + entry, 1)
+          )
+          open('release-entry.txt', 'w').write(entry)
+          PYEOF
+
+      - name: Write job summary
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          DEP_NAME:    ${{ steps.metadata.outputs.dependency-names }}
+          DEP_FROM:    ${{ steps.metadata.outputs.previous-version }}
+          DEP_TO:      ${{ steps.metadata.outputs.new-version }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Release v${NEW_VERSION} — pending approval
+
+          | | |
+          |---|---|
+          | **Version**    | \`${NEW_VERSION}\` |
+          | **Dependency** | \`${DEP_NAME}\`    |
+          | **Change**     | \`${DEP_FROM}\` → \`${DEP_TO}\` |
+          EOF
+
+      - name: Upload prepared files
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-files
+          path: |
+            Cargo.toml
+            CHANGELOG.md
+            release-entry.txt
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Job 2 — Publish (requires manual approval on the "release" environment)
+  # Commits the prepared files, pushes the tag, optionally updates main,
+  # propagates the changelog to higher branches, then publishes to crates.io.
+  #
+  # Setup required (one-time):
+  #   • Settings → Environments → create "release" → add yourself as reviewer
+  #   • Add CARGO_REGISTRY_TOKEN as a secret of that environment
+  #   • If the release branch is protected: allow "github-actions[bot]" to bypass
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Download prepared files
+        uses: actions/download-artifact@v4
+        with:
+          name: release-files
+          path: .
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit, tag and push to release branch
+        run: |
+          TARGET="${{ github.event.pull_request.base.ref }}"
+          git add Cargo.toml CHANGELOG.md
+          git commit -m "chore: release v${{ needs.prepare.outputs.new_version }} [skip ci]"
+          git tag "v${{ needs.prepare.outputs.new_version }}"
+          git push origin "$TARGET" --follow-tags
+
+      # Only the branch that carries the highest major version mirrors main.
+      - name: Push to main (highest major only)
+        if: needs.prepare.outputs.is_highest_major == 'true'
+        run: |
+          git push origin HEAD:main
+
+      # For every N.x branch whose major is higher than ours, prepend the same
+      # CHANGELOG entry so that users of higher versions can see lower-branch
+      # dependency history without switching branches.
+      - name: Propagate changelog entry to higher branches
+        if: needs.prepare.outputs.higher_branches != ''
+        env:
+          HIGHER_BRANCHES: ${{ needs.prepare.outputs.higher_branches }}
+          NEW_VERSION:     ${{ needs.prepare.outputs.new_version }}
+        run: |
+          IFS=',' read -ra BRANCHES <<< "$HIGHER_BRANCHES"
+          for branch in "${BRANCHES[@]}"; do
+            echo "Propagating v${NEW_VERSION} changelog to ${branch}"
+            git fetch origin "${branch}"
+            git worktree add "/tmp/propagate-${branch}" "origin/${branch}"
+            BRANCH="${branch}" python3 - <<'PYEOF'
+          import os
+          branch  = os.environ['BRANCH']
+          entry   = open('release-entry.txt').read()
+          path    = f'/tmp/propagate-{branch}/CHANGELOG.md'
+          content = open(path).read()
+          open(path, 'w').write(
+              content.replace('# Changelog\n\n', '# Changelog\n\n' + entry, 1)
+          )
+          PYEOF
+            git -C "/tmp/propagate-${branch}" add CHANGELOG.md
+            git -C "/tmp/propagate-${branch}" commit \
+              -m "chore: propagate v${NEW_VERSION} changelog from lower branch [skip ci]"
+            git -C "/tmp/propagate-${branch}" push origin "HEAD:${branch}"
+            git worktree remove "/tmp/propagate-${branch}"
+          done
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          gh release create "v${{ needs.prepare.outputs.new_version }}" \
+            --title "v${{ needs.prepare.outputs.new_version }}" \
+            --notes "Automated patch release — see [CHANGELOG.md](CHANGELOG.md) for details."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -16,17 +16,19 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Verify MSRV (1.85)
+        uses: dtolnay/rust-toolchain@1.85
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install audit tool
-        run: cargo install cargo-audit
 
       # --- Build minimal ---
       - name: Build (no default features)
@@ -45,5 +47,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       # --- Security audit ---
-      - name: Cargo audit
-        run: cargo audit --locked
+      - name: Security audit
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -10,23 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        features:
-          - ""                              # no default features
-          - "verify"
-          - "dry-run"
-          - "analyze"
-          - "error-stack"
-          - "log"
-          - "secure_log"
-          - "verify,error-stack"
-          - "verify,secure_log"
-          - "error-stack,log"
-          - "error-stack,secure_log"
-          - "all"
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,15 +17,19 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install nextest
-        run: cargo install cargo-nextest
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run tests
-        run: |
-          if [ "${{ matrix.features }}" = "" ]; then
-            cargo nextest run --no-default-features
-          elif [ "${{ matrix.features }}" = "all" ]; then
-            cargo nextest run --all-features
-          else
-            cargo nextest run --no-default-features --features "${{ matrix.features }}"
-          fi
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Test all feature combinations
+        run: cargo hack nextest run --feature-powerset --test-threads 1

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,223 @@
+# Architecture
+
+This document describes the internal architecture of **Nozomi v3.1.x**.
+
+It is intended for contributors and maintainers who want to understand how the
+library is structured and how secure deletion operations are executed.
+
+---
+
+## Principles
+
+**Explicit configuration** — all operations are configured through a builder.
+No implicit behavior, no global state.
+
+**Stable public API** — breaking changes are reserved for major releases only.
+The internal engine can be refactored freely without affecting the public API.
+
+**Minimal default build** — no optional capability is enabled by default.
+Every optional behavior is controlled through a Cargo feature.
+
+**Event-driven observability** — the engine emits structured events during
+execution. Events are informational only and never influence control flow.
+
+---
+
+## Module Map
+
+```
+src/
+├── lib.rs                        # Crate root — re-exports public surface
+├── methods.rs                    # Method enum (7 built-in sanitisation standards)
+├── models.rs                     # SecureDelete (deprecated since 3.1.0)
+├── analyze.rs                    # PassKind, PassInfo, AnalysisReport  [feature: analyze]
+│
+├── error/
+│   ├── mod.rs                    # FSProblem enum (low-level I/O problem codes)
+│   ├── standard.rs               # Error, Result  (default)
+│   └── enhanced.rs               # Error, Result  [feature: error-stack, deprecated]
+│
+├── api/
+│   └── delete/
+│       ├── mod.rs                # Module doc and re-exports
+│       ├── builder.rs            # DeleteRequestBuilder — fluent configuration
+│       ├── request.rs            # DeleteRequest, DeleteMethod, NoopSink
+│       ├── report.rs             # DeleteReport — result of a completed deletion
+│       └── legacy.rs             # From<SecureDelete> migration bridge
+│
+└── engine/                       # Private — not part of the public API
+    ├── mod.rs                    # Engine entry point
+    ├── events.rs                 # DeleteEvent enum, EventSink trait
+    ├── planner.rs                # ExecutionPlan, execution_plan()
+    ├── executor.rs               # run(), dry_run()
+    ├── utils.rs                  # delete_file(), delete_dir(), emit_safe()
+    ├── verify.rs                 # verify_last_pass()             [feature: verify]
+    └── overwrite/
+        ├── mod.rs                # Method dispatcher
+        ├── common.rs             # prepare_overwrite() — shared buffer logic
+        ├── afssi_5020.rs         # AFSSI 5020          (3 passes)
+        ├── dod_522022_me.rs      # DoD 5220.22-M ME    (3 passes)
+        ├── dod_522022_mece.rs    # DoD 5220.22-M ECE   (7 passes)
+        ├── hmgi_s5.rs            # HMGI S5             (2 passes)
+        ├── pseudo_random.rs      # PseudoRandom        (1 pass)
+        ├── rcmp_tssit_ops_ii.rs  # RCMP TSSIT OPS-II   (7 passes)
+        └── gutmann.rs            # Gutmann             (35 passes)
+```
+
+---
+
+## Public API
+
+### `DeleteRequestBuilder`  (`src/api/delete/builder.rs`)
+
+Entry point for all deletion operations. Exposes a fluent builder that
+collects the target path and the chosen overwrite method, then produces
+a validated `DeleteRequest`.
+
+```rust
+DeleteRequest::builder()
+    .path("/path/to/file")
+    .method(DeleteMethod::BuiltIn(Method::Gutmann))
+    .build()?
+```
+
+### `DeleteRequest`  (`src/api/delete/request.rs`)
+
+Immutable, fully validated deletion request. Calling `.run()` hands it
+to the execution engine. Calling `.run_with(sink)` additionally forwards
+structured events to a caller-supplied `EventSink`.
+
+### `DeleteReport`  (`src/api/delete/report.rs`)
+
+Returned on successful completion. Carries the resolved path and the
+method that was used.
+
+### `DeleteMethod`  (`src/api/delete/request.rs`)
+
+Selects the overwrite strategy. Currently, holds a single variant:
+
+```rust
+pub enum DeleteMethod {
+    BuiltIn(Method),
+}
+```
+
+Additional variants (user-defined strategies) are planned for v4.x via
+the `OverwriteMethod` trait.
+
+### `Method`  (`src/methods.rs`)
+
+Enumerates the seven built-in sanitisation standards.
+
+| Variant          | Standard            | Passes |
+|------------------|---------------------|:------:|
+| `PseudoRandom`   | Random data         |   1    |
+| `HmgiS5`         | HMGI S5             |   2    |
+| `Afssi5020`      | AFSSI 5020          |   3    |
+| `Dod522022ME`    | DoD 5220.22-M (ME)  |   3    |
+| `RcmpTssitOpsII` | RCMP TSSIT OPS-II   |   7    |
+| `Dod522022MECE`  | DoD 5220.22-M (ECE) |   7    |
+| `Gutmann`        | Gutmann             |   35   |
+
+---
+
+## Execution Flow
+
+```
+DeleteRequest::run()
+        │
+        ▼
+engine::executor::run()
+        │
+        ├─ 1. planner::execution_plan()
+        │        └─ walks the filesystem tree
+        │           returns ExecutionPlan { files: Vec<PathBuf>, directories: Vec<PathBuf> }
+        │           (directories are ordered deepest-first for safe removal)
+        │
+        ├─ 2. For each file:
+        │        ├─ emit DeletionStarted
+        │        ├─ overwrite::overwrite_file()          ← dispatches to method module
+        │        │       └─ N passes via prepare_overwrite()
+        │        │            ├─ fill buffer (zero / pattern / random)
+        │        │            ├─ write buffer to file
+        │        │            ├─ fsync
+        │        │            └─ emit EntryOverwritePass { pass, total_passes }
+        │        ├─ [verify::verify_last_pass()]         [feature: verify]
+        │        ├─ utils::delete_file()
+        │        │       └─ progressive zero-rename strategy before unlink
+        │        ├─ emit EntryDeleted
+        │        └─ emit DeletionFinished
+        │
+        └─ 3. For each directory (deepest first):
+                 ├─ utils::delete_dir()
+                 ├─ emit EntryDeleted
+                 └─ emit DeletionFinished
+```
+
+---
+
+## Event System  (`src/engine/events.rs`)
+
+The `EventSink` trait decouples the engine from any consumer-side logic:
+
+```rust
+pub trait EventSink {
+    fn emit(&mut self, event: DeleteEvent);
+}
+```
+
+Rules enforced by the engine:
+
+- Events are emitted via `utils::emit_safe()`, which catches panics from
+  sink implementations so that a buggy sink can never abort a deletion.
+- Events are **informational only** — a sink cannot affect control flow.
+- Errors are always returned through `Result`, never through events.
+
+`NoopSink` (in `request.rs`) is the default sink used by `run()`.
+Consumers who need events call `run_with(sink)` instead.
+
+---
+
+## Optional Features
+
+| Feature       | Effect                                                                         |
+|---------------|--------------------------------------------------------------------------------|
+| `dry-run`     | Adds `dry_run()` / `dry_overwrite_file()` paths — emits events without I/O     |
+| `verify`      | Adds `verify_last_pass()` — reads back the final pass to confirm correctness   |
+| `analyze`     | Exposes `Method::analyze()` → `AnalysisReport` with the full pass schedule     |
+| `log`         | Emits `trace!` entries via the `log` façade at key engine steps                |
+| `secure_log`  | Like `log`, but replaces file paths with their MD5 hash                        |
+| `error-stack` | *(Deprecated — removed in 4.0.0)* Wraps errors in `error_stack::Report<Error>` |
+
+Every public function that can return an error is compiled twice when
+`error-stack` is active: once under `#[cfg(not(feature = "error-stack"))]`
+and once under `#[cfg(feature = "error-stack")]`. This duplication is
+eliminated when the feature is removed in v4.0.0.
+
+---
+
+## Legacy API  (`src/models.rs`, `src/api/delete/legacy.rs`)
+
+`SecureDelete` was the primary API before v3.1.0. It is now deprecated
+and will be **removed in v4.0.0**. A `From<SecureDelete>` impl in
+`legacy.rs` provides a migration bridge to `DeleteRequestBuilder`.
+
+Contributors must not introduce new dependencies on any legacy type.
+
+---
+
+## Evolution Towards v4.x
+
+The following architectural changes are planned for v4.0.0 (see open issues):
+
+- **Remove `error-stack` feature and legacy API** — eliminates all code duplication.
+- **Redesign the error model** — split the flat `Error` enum into
+  `PlanningError`, `ExecutionError`, and `IoError`.
+- **`OverwriteMethod` trait** — replaces the hardcoded dispatcher with a
+  trait-based extension point, enabling user-defined overwrite strategies.
+- **Deletion policies** — high-level aliases (NIST 800-88, DoD) above
+  the raw `Method` enum.
+- **Filesystem safety detection** — emit a warning event when the target
+  filesystem may interfere with secure deletion (SSD, copy-on-write, network).
+- **Dangerous target safeguards** — reject critical paths (`/`, `/etc`, `/usr`)
+  unless an explicit override is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v3.1.0](https://crates.io/crates/nozomi/3.1.0)
+
+```diff
+Project change :
+! log : 0.4.27 --> 0.4.29
+! rand : 0.9.1 --> 0.10.1
+! error-stack : 0.5.0 --> 0.6.1
+
+New features :
++ Add `dry-run` feature : simulate a deletion run without writing to disk
++ Add `verify` feature : read back the last overwrite pass to confirm correctness
++ Add `analyze` feature : inspect the pass schedule of a method before running it
+
+API :
++ Add `DeleteRequest` builder API as the new primary entry point
++ Add `DeleteEvent` and `EventSink` for progress tracking during deletion
++ Add `DeleteReport` as the return type for a completed deletion
+- Mark `SecureDelete` API as deprecated (will be removed in 4.0.0)
+
+Internal :
+! Refactor engine into a dedicated module (overwrite, planner, executor, verify)
+! Apply feature gating across the entire engine
+```
+
 ## [v3.0.3](https://crates.io/crates/nozomi/3.0.3)
 
 ```diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,527 +1,178 @@
-# Nozomi contribution guideline
+# Contributing to Nozomi
 
-This document serves as a reference and contains all the good practices to be applied if you wish to participate in the development of this project.
+Thank you for considering contributing to **Nozomi**.
 
-## Tables of content
-1. [**Version control policy** *(vX.Y.Z)*](#version-control-policy-vxyz)
-    1. [**Major version** *(vX.0.0)*](#major-version-vx00)
-    2. [**Minor version** *v1.Y.0*](#minor-version-v1y0)
-    3. [**Patch** *v1.1.Z*](#patch-v11z)
+Nozomi is a Rust library for secure file and directory deletion. Because
+the library performs **irreversible operations on user data**,
+correctness, predictability, and security are critical.
 
-2. [New Erase Method](#new-erase-method)
-    1. [What to check before ask for a new erase method](#what-to-check-before-ask-for-a-new-erase-method)
-    2. [Modification process](#modification-process)
-    3. [New method file template](#new-method-file-template)
-    4. [Update in src/methods/mod.rs](#update-in-srcmethodsmodrs)
-3. [Other kind of contribution](#other-kind-of-contribution)
-    1. [Examples](#examples)
-    2. [Issues](#issues)
-    3. [Spell Check](#spell-check)
-    4. [Documenting](#documenting)
+This document explains how to contribute to the project.
 
-# **Version control policy** *(vX.Y.Z)*
-## **Major version** *(vX.0.0)*
-```diff
-+ INFO : Each code refactorization of a new deletion method will result in a major change
-```
-A major release is a release that contains changes that are destructive to the user. So, if he changes to a more recent major version then he will have to modify his code 
+------------------------------------------------------------------------
 
+## Table of Contents
 
-*I hope that 2.x will be my last major version...*
-### Example :
-```rust
-use nozomi::EraserEntity::PseudoRandom; // v1.0.2
-use nozomi::OverwriteMethod::PseudoRandom; //v2.0.0
-```
+-   [Versioning Policy](#versioning-policy)
+-   [Project Architecture (3.1.x series)](#project-architecture-31x-series)
+-   [Adding a New Erase Method](#adding-a-new-erase-method)
+-   [Other Contributions](#other-contributions)
+-   [Running Tests](#running-tests)
+-   [Maintainer Notes](#maintainer-note)
 
-## **Minor version** *v1.Y.0*
-```diff
-+ INFO : Each addition of a new deletion method will result in a minor change
-```
-A minor release is a release that contains changes that are not destructive to the user. So, if he changes to a more recent he will not have to modify his code.
+------------------------------------------------------------------------
 
+## Versioning Policy
 
-## **Patch** *v1.1.Z*
-```diff
-+ INFO : Each dependency update will result in a new patch version
-! INFO : Each typo or grammar correction will not result in a new patch version
-```
-A dependency or internal documentation update 
+Nozomi follows **Semantic Versioning**.
 
-# New Erase Method
+Version format: `vX.Y.Z`
 
-## What to check before ask for a new erase method
-- [ ] Does the new method I want to implement have an RFC in the issue?
-- [ ] Is the RFC not being reviewed / tested / implemented?
-- [ ] Is the name of my method in line with the code of conduct?
-- [ ] Is the name of my method unique?
-- [ ] Is my method documented somewhere (book, internet)?
+### Major version (`vX.0.0`)
 
-All good? Then great, no worries, you can add your method!
+Major versions introduce **breaking changes** to the public API.
 
-## Modification process
-1) Add your methods as a rs file in [src/methods/](src/methods/) folder (cf. )
-2) Fill the template with your logic ([cf. ](#add-new-method-in-enum))
-3) Add new method in the [src/methods/mod.rs](src/methods/mod.rs) in Method enum ([cf.](#add-new-method-in-enum))
-4) Update display trait ([cf.](#update-method-display-trait))
-5) Update delete file function([cf.](#update-delete-file-function))
-5) Update delete folder function([cf.](#update-delete-folder-function))
+Examples:
 
-## New method file template
+-   removal of deprecated APIs
+-   architectural redesign
+-   public API refactoring
 
-```rust
-use crate::models::SecureDelete;
-use crate::Method;
+Users upgrading to a new major version may need to modify their code.
 
-// -- Region : feature import
-#[cfg(not(feature = "error-stack"))]
-use crate::{Error, Result};
+------------------------------------------------------------------------
 
-#[cfg(feature = "log")]
-use log::info;
+### Minor version (`v1.Y.0`)
 
-#[cfg(feature = "error-stack")]
-use crate::{Error, Result};
-#[cfg(feature = "error-stack")]
-use error_stack::ResultExt;
+Minor releases introduce **new functionality without breaking the public
+API**.
 
+Examples:
 
-// -- Region : Pseudo Random overwriting method for basic error handling method
+-   new erase methods
+-   new optional features
+-   internal improvements
 
-#[cfg(not(feature = "error-stack"))]
-pub fn overwrite_file(path: &str) -> Result<SecureDelete> {
-    // TODO : Add your logic here
-    Ok(secure_deletion)
-}
+Upgrading between minor versions should not require code changes.
 
-// -- Region : Pseudo Random overwriting method for error-stack error handling method
+------------------------------------------------------------------------
 
-#[cfg(feature = "error-stack")]
-pub fn overwrite_file(path: &str) -> Result<SecureDelete> {
-    // TODO : Add your logic here
-    Ok(secure_deletion)
-}
+### Patch version (v1.1.Z)
 
-// -- Region : Tests 
-#[cfg(test)]
-mod test {
-    
-    const METHOD_NAME: &str = "pseudo_random"; // TODO : UPDATE HERE
+Patch releases include:
 
-    use crate::Method::PseudoRandom as EraseMethod; // TODO : UPDATE HERE
+-   dependency updates
+-   bug fixes
+-   internal improvements
 
-    // ! DO NOT CHANGE THE CODE BELLOW THIS POINT
-    use super::overwrite_file;
-    use crate::error::FSProblem;
-    use crate::tests::TestType;
+Documentation or spelling corrections do **not necessarily require a
+release**.
 
-    /// Module containing all the tests for the standard error handling method
-    #[cfg(not(feature = "error-stack"))]
-    mod standard {
-        use super::*;
+------------------------------------------------------------------------
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+## Project Architecture (3.1.x series)
 
-        #[cfg(not(any(feature = "log", feature = "secure_log")))]
-        mod no_log {
-            use pretty_assertions::{assert_eq, assert_ne};
-            use std::path::Path;
+Version **3.1** introduced several architectural improvements intended
+to increase long‑term maintainability.
 
-            use super::*;
+Deletion operations follow the structure below:
 
-            /// Test if the overwrite method for this particular erase protocol work well or not.
-            ///
-            /// Test success is all conditions are met :
-            /// * function overwrite_file is success
-            /// * file is overwritten
-            /// * file is overwritten with good method
-            /// * file is well deleted
-            #[test]
-            fn basic_overwrite() -> Result<()> {
-                let (string_path, lorem) =
-                    create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                overwrite_file(&string_path)?;
-                let bytes = get_bytes(&path)?;
-                assert_eq!(bytes.len(), lorem.as_bytes().len());
-                assert_ne!(bytes, lorem.as_bytes());
-                std::fs::remove_file(&string_path).map_err(|_| {
-                    Error::SystemProblem(FSProblem::Delete, string_path.to_string())
-                })?;
-                Ok(())
-            }
+Public API → Builder → Internal Engine
 
-            /// This test checks whether a 1KB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            fn small_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::SmallFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+The internal engine coordinates:
 
-            /// This test checks whether a 1MB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            fn medium_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::MediumFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!Path::new(&string_path).exists());
-                Ok(())
-            }
+-   planning deletion operations
+-   executing overwrite passes
+-   filesystem interactions
 
-            /// This test checks whether a 10MB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            #[ignore = "test too long"]
-            fn large_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::LargeFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+The execution engine is intentionally **private** so internal
+refactoring does not break the public API.
 
-            /// The test can be used to check whether a folder can be deleted using a particular method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific folder with multiple files in it is created
-            /// * folder is delete thanks to the specific erasing method
-            #[test]
-            fn folder_test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::Folder, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+------------------------------------------------------------------------
 
-            /// This test checks whether an error is returned when a file is read-only and a user tries to delete it using a particular method..
-            ///
-            /// Test success is all conditions are met :
-            /// * A readonly file is created
-            /// * An error is returned
-            /// * The file is deleted at the end of the test
-            #[test]
-            fn permission_denied() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::WritingError, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                let result = EraseMethod.delete(&string_path);
-                println!("{:?}", result);
-                assert!(result.is_err());
-                let mut perms = path.metadata().unwrap().permissions();
-                perms.set_readonly(false);
-                std::fs::set_permissions(&string_path, perms).map_err(|_| {
-                    Error::SystemProblem(FSProblem::Permissions, string_path.clone())
-                })?;
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
+### Feature Gating
 
-        #[cfg(all(feature = "log", not(feature = "secure_log")))]
-        mod log {
-            use super::*;
-            use std::path::Path;
+Optional capabilities are controlled through Cargo features.
 
-            /// The test ensures that the feature log functions correctly for basic error handling.
-            ///
-            /// Test success is all conditions are met :
-            /// * A specific file is created
-            /// * The file is deleted without any error
-            #[test]
-            fn test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::LogMini, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
+Default configuration:
 
-        #[cfg(feature = "secure_log")]
-        mod secure_log {
-            use super::*;
-            use std::path::Path;
+    default = []
 
-            /// The test ensures that the feature secure_log functions correctly for basic error handling.
-            ///
-            /// Test success is all conditions are met :
-            /// * A specific file is created
-            /// * The file is deleted without any error
-            #[test]
-            fn test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::SecureLog, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
-    }
+Contributors must ensure that:
 
-    /// Module containing all the tests for the error-stack handling method
-    #[cfg(feature = "error-stack")]
-    mod enhanced {
-        use super::*;
+-   the default build remains minimal
+-   optional features are properly gated
+-   feature combinations compile independently
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+------------------------------------------------------------------------
 
-        #[cfg(not(any(feature = "log", feature = "secure_log")))]
-        mod no_log {
-            use error_stack::ResultExt;
-            use pretty_assertions::{assert_eq, assert_ne};
-            use std::path::Path;
+### Legacy Compatibility
 
-            use super::*;
+Some legacy APIs remain available in the **3.x series** for
+compatibility.
 
-            /// Test if the overwrite method for this particular erase protocol work well or not.
-            ///
-            /// Test success is all conditions are met :
-            /// * function overwrite_file is success
-            /// * file is overwritten
-            /// * file is overwritten with good method
-            /// * file is well deleted
-            #[test]
-            fn basic_overwrite() -> Result<()> {
-                let (string_path, lorem) =
-                    create_test_file(&TestType::OverwriteOnly, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                overwrite_file(&string_path)?;
-                let bytes = get_bytes(&path)?;
-                assert_eq!(bytes.len(), lorem.as_bytes().len());
-                assert_ne!(bytes, lorem.as_bytes());
-                std::fs::remove_file(&string_path).change_context(Error::SystemProblem(
-                    FSProblem::Delete,
-                    string_path.to_string(),
-                ))?;
-                Ok(())
-            }
+These APIs are **deprecated** and will be removed in **version 4.0.0**.
 
-            /// This test checks whether a 1KB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            fn small_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::SmallFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+Contributors should avoid introducing new dependencies on legacy code.
 
-            /// This test checks whether a 1MB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            fn medium_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::MediumFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!Path::new(&string_path).exists());
-                Ok(())
-            }
+------------------------------------------------------------------------
 
-            /// This test checks whether a 10MB file is correctly rewritten and deleted for a given delete method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific file is created
-            /// * file is delete thanks to the specific erasing method
-            #[test]
-            #[ignore = "test too long"]
-            fn large_deletion() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::LargeFile, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+## Adding a New Erase Method
 
-            /// The test can be used to check whether a folder can be deleted using a particular method.
-            ///
-            /// Test success is all conditions are met :
-            /// * a specific folder with multiple files in it is created
-            /// * folder is delete thanks to the specific erasing method
-            #[test]
-            fn folder_test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::Folder, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
+New erase methods are welcome but must follow a structured process.
 
-            /// This test checks whether an error is returned when a file is read-only and a user tries to delete it using a particular method..
-            ///
-            /// Test success is all conditions are met :
-            /// * A readonly file is created
-            /// * An error is returned
-            /// * The file is deleted at the end of the test
-            #[test]
-            fn permission_denied() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::WritingError, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                let result = EraseMethod.delete(&string_path);
-                println!("{:?}", result);
-                assert!(result.is_err());
-                let mut perms = path.metadata().unwrap().permissions();
-                perms.set_readonly(false);
-                std::fs::set_permissions(&string_path, perms).change_context(
-                    Error::SystemProblem(FSProblem::Permissions, string_path.clone()),
-                )?;
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
+Before implementing a new method:
 
-        #[cfg(all(feature = "log", not(feature = "secure_log")))]
-        mod log {
-            use super::*;
-            use std::path::Path;
+-   Ensure the method is documented in a reliable source
+-   Ensure it is not already implemented
+-   Open an issue or discussion describing the proposal
 
-            /// The test ensures that the feature log functions correctly
-            ///
-            /// Test success is all conditions are met :
-            /// * A specific file is created
-            /// * The file is deleted without any error
-            #[test]
-            fn test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::LogMini, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
+Implementation steps:
 
-        #[cfg(feature = "secure_log")]
-        mod secure_log {
-            use super::*;
-            use std::path::Path;
+1.  Create a new file in: `src/engine/overwrite.rs`
 
-            /// The test ensures that the feature secure_log functions correctly.
-            ///
-            /// Test success is all conditions are met :
-            /// * A specific file is created
-            /// * The file is deleted without any error
-            #[test]
-            fn test() -> Result<()> {
-                let (string_path, _) = create_test_file(&TestType::SecureLog, &METHOD_NAME)?;
-                let path = Path::new(&string_path);
-                assert!(path.exists());
-                EraseMethod.delete(&string_path)?;
-                assert!(!path.exists());
-                Ok(())
-            }
-        }
-    }
-}
+2.  Implement the overwrite logic.
 
+3.  Register the method in: `src/methods.rs`
 
+4.  Implement the `Display` trait for the method.
+
+5.  Add unit tests.
+
+------------------------------------------------------------------------
+
+## Other Contributions
+
+Not all contributions involve implementing new erase methods.
+
+Other useful contributions include:
+
+-   improving documentation
+-   fixing bugs
+-   adding examples
+-   correcting spelling or grammar
+-   improving tests
+
+------------------------------------------------------------------------
+
+## Running Tests
+
+Before submitting a pull request, please run the test suite.
+```shell
+    cargo test
+    cargo test --all-features
+    cargo clippy --all-features
 ```
 
-## Update in [src/methods/mod.rs](src/methods/mod.rs)
-
-### Add new method in enum
-```rust
-pub enum Method {
-    /// DOD 522022 MECE erasing method <https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php>
-    Dod522022MECE,
-    ...
-    #[default]
-    PseudoRandom,
-    // TODO add doc with link
-    MethodName, // TODO : Update here
-}
+Optional faster test runner:
+```shell
+cargo nextest run
 ```
+All tests should pass before submitting a pull request.
 
-### Update Method display trait
-```rust
-// -- Region : Implement display trait for Method enum.
-impl core::fmt::Display for Method {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
-        match self {
-            Method::Dod522022MECE => write!(fmt, "DOD 522022 MECE"),
-            ...
-            Method::PseudoRandom => write!(fmt, "Pseudo Random"),
-            // TODO Add new method display trait implementation
-        }
-    }
-}
+------------------------------------------------------------------------
 
-```
-### Update delete file function
-```rust
-match self {
-    Method::Dod522022MECE => dod_522022_me::overwrite_file(path)?.delete()?,
-    ...
-    Method::PseudoRandom => pseudo_random::overwrite_file(path)?.delete()?,
-    // TODO : Add your method here
-};
+## Maintainer Note
 
-```
+This project is maintained during personal time.
 
-# Other kind of contribution
-## Examples
-Feel free to add as many different examples as you like as long as they are not redundant.
-```diff
-! In the first title of the README.md remember to put the version of the library used to make the example
-```
-```
-examples/
-  |- example_1/
-      |- README.md
-      |- Cargo.toml
-      |- src/
-          |- main.rs
-          |- ...
-```
-## Issues
-/// TODO
-
-## Spell Check
-As you may have noticed, I make a lot of grammatical and spelling mistakes. Although I do everything I can to try and correct them before I post, it is possible (even certain) that some remain.
-
-So, if you see any, please do not hesitate and thank you very much.
-
-## Documenting
-I try to do my best to ensure that the code is well documented. This also applies to README, CONTRIBUTING, etc.
-
-If you ever feel that a part of the code is not explicit enough or lacks clarity, please feel free to open a discussion. I will try to answer as soon as possible.
-
-To tell you the truth, this is the first open-source project I've published and I want to make it as professional as possible. So, of course, I'm open to any kind of criticism.
+Suggestions, improvements, and constructive feedback are always welcome.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "nozomi"
-version = "3.0.3"
+version = "3.1.0"
 edition = "2024"
+rust-version = "1.85"
 
-authors = ["Sans-Atout <augustin.rousset-rouviere@isep.fr>"]
+authors = ["Sans-Atout <augustin@rousset-rouviere.fr>"]
 description = "Equivalent of the Linux shred command but in rust and library. Allows you to securely erase data from a hard drive."
 keywords = ["security", "erase", "eraser", "wiping", "wiper"]
 
@@ -11,12 +12,12 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Sans-Atout/Nozomi/"
 
 [dependencies]
-error-stack = {version = "0.6.0",optional=true}
-rand = "0.10.0"
+error-stack = {version = "0.7.0",optional=true}
+rand = "0.10.1"
 md5 = { version = "0.8.0", optional=true}
 
 [dependencies.log]
-version = "0.4.27"
+version = "0.4.29"
 optional = true
 
 [lints.rust]
@@ -29,8 +30,6 @@ pretty_assertions = "1.4.1"
 maintenance = { status = "actively-developed" }
 
 [features]
-# No optional capability enabled by default.
-# The default build must remain minimal and predictable.
 default = []
 
 # Functional capabilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ authors = ["Sans-Atout <augustin.rousset-rouviere@isep.fr>"]
 description = "Equivalent of the Linux shred command but in rust and library. Allows you to securely erase data from a hard drive."
 keywords = ["security", "erase", "eraser", "wiping", "wiper"]
 
-license = "GPL-3.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/Sans-Atout/Nozomi/"
 
 [dependencies]
-error-stack = {version = "0.5.0",optional=true}
-rand = "0.9.1"
-md5 = { version = "0.7.0", optional=true}
+error-stack = {version = "0.6.0",optional=true}
+rand = "0.10.0"
+md5 = { version = "0.8.0", optional=true}
 
 [dependencies.log]
 version = "0.4.27"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,137 @@
+# Migration Guide
+
+This document covers breaking changes between major versions of **Nozomi**
+and explains how to update your code.
+
+---
+
+## Migrating from 2.x / 3.0.x to 3.1.0
+
+### The deletion API has changed
+
+Before 3.1.0, deletions were triggered through static methods on the `Method`
+enum or through the `SecureDelete` struct:
+
+```rust
+// 2.x style — SecureDelete static methods
+use nozomi::SecureDelete;
+SecureDelete::afssi_5020("path/to/file")?;
+
+// 3.0.x style — Method::delete()
+use nozomi::Method::Afssi5020;
+Afssi5020::delete("path/to/file")?;
+```
+
+These APIs are **deprecated in 3.1.0** and will be **removed in 4.0.0**.
+
+The new API uses a builder:
+
+```rust
+use nozomi::{DeleteRequest, DeleteMethod, Method};
+
+let report = DeleteRequest::builder()
+    .path("path/to/file")
+    .method(DeleteMethod::BuiltIn(Method::Afssi5020))
+    .build()?
+    .run()?;
+```
+
+### Quick reference
+
+| Before (≤ 3.0.x)                             | After (3.1.0+)                                                                                         |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `Method::Gutmann::delete("path")`            | `DeleteRequest::builder().path("path").method(DeleteMethod::BuiltIn(Method::Gutmann)).build()?.run()?` |
+| `SecureDelete::gutmann("path")`              | same as above                                                                                          |
+| `Method::Gutmann::delete_with("path", sink)` | `.run_with(sink)?`                                                                                     |
+
+### Receiving progress events
+
+The old API had no event system. The new API supports an optional `EventSink`:
+
+```rust,no_run
+use nozomi::{DeleteRequest, DeleteMethod, Method, EventSink, DeleteEvent};
+
+struct MyLogger;
+
+impl EventSink for MyLogger {
+    fn emit(&mut self, event: DeleteEvent) {
+        println!("{:?}", event);
+    }
+}
+
+DeleteRequest::builder()
+    .path("path/to/file")
+    .method(DeleteMethod::BuiltIn(Method::Gutmann))
+    .build()?
+    .run_with(&mut MyLogger)?;
+# Ok::<(), nozomi::Error>(())
+```
+
+### The `error-stack` feature is deprecated
+
+If your project enabled the `error-stack` feature, it still works in 3.1.0
+but will be **removed in 4.0.0**. Remove it now to avoid a harder migration
+later:
+
+```toml
+# Before
+nozomi = { version = "3.1.0", features = ["error-stack"] }
+
+# After
+nozomi = { version = "3.1.0" }
+```
+
+Adjust your error handling to use the standard `nozomi::Error` type directly.
+
+---
+
+## Migrating from 3.x to 4.0.0  *(upcoming)*
+
+> This section will be completed when v4.0.0 is released.
+> The changes below reflect the current roadmap.
+
+### Legacy API removed
+
+`SecureDelete`, `Method::delete()`, and all associated types will be removed.
+The builder-based `DeleteRequest` API becomes the only entry point.
+
+If you followed the migration steps above for 3.1.0, no further changes will
+be needed for this part of the migration.
+
+### Error model redesigned
+
+The flat `Error` enum will be replaced by a structured hierarchy:
+
+```rust
+// Planned (4.0.0)
+pub enum Error {
+    Planning(PlanningError),
+    Execution(ExecutionError),
+    Io(IoError),
+}
+```
+
+Update your `match` arms accordingly when 4.0.0 is released.
+
+### `error-stack` feature removed
+
+The `error-stack` feature is removed entirely. Any code still using it must
+be updated to the standard error type before upgrading to 4.0.0.
+
+### Custom overwrite strategies
+
+v4.0.0 will introduce an `OverwriteMethod` trait. If you were working around
+the absence of custom methods in 3.x, this will be the supported extension
+point.
+
+---
+
+## Support lifecycle
+
+| Version | Status              | End of support |
+|---------|---------------------|----------------|
+| 3.x     | Actively supported  | —              |
+| 2.x     | Passively supported | 02 Jun 2029    |
+| 1.x     | Yanked              | 02 Jun 2025    |
+
+See [README.md](README.md#support) for the full support policy.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,154 @@
 # Nozomi
 
-A Rust library that wipe all file or folder. \
-This library includes most of the secure deletion methods of the [Eraser](https://eraser.heidi.ie) for Windows software.
+[![Crates.io](https://img.shields.io/crates/v/nozomi)](https://crates.io/crates/nozomi)
+[![Docs.rs](https://docs.rs/nozomi/badge.svg)](https://docs.rs/nozomi)
+[![License](https://img.shields.io/crates/l/nozomi)](#license)
+[![maintenance-status: actively-developed](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)](https://crates.io/crates/nozomi)
 
-# Add to your project
+A Rust library for **secure file deletion**. Nozomi overwrites file contents with
+industry-standard byte patterns before removing them from the filesystem, making
+data recovery significantly harder on traditional storage media.
+
+It implements the same sanitisation standards as the
+[Eraser](https://eraser.heidi.ie) software for Windows.
+
+> **SSD users — read the [important notice](#-important-notice-for-ssd-users)
+> before integrating this library.**
+
+---
+
+## Quick start
+
 ```toml
 [dependencies]
 nozomi = "3.0.3"
 ```
 
-## Test libraries
-### Prerequire (optional)
-```shell
-cargo install cargo-nextest
-```
-
-### Test
-```shell
-git clone https://github.com/Sans-Atout/Nozomi.git
-cd Nozomi
-cargo nextest run
-```
-
-## Code example
 ```rust
-use nozomi::Method::Afssi5020;
+use nozomi::{DeleteRequest, DeleteMethod, Method};
 
-fn main() -> Result<(),nozomi::Error> {
-    Afssi5020::delete("path/to/file.txt")?;
-    // OR
-    match Afssi5020::delete("path/to/file.txt"){
-        Ok(info) => println!("{}",info), // If you want
-        Err(error) => println!("{}",error)
-    };
+let report = DeleteRequest::builder()
+    .path("/path/to/sensitive/file.txt")
+    .method(DeleteMethod::BuiltIn(Method::Gutmann))
+    .build()?
+    .run()?;
 
-    Ok(())
-}
+println!("Deleted {:?} using {}", report.path, report.method);
 ```
 
-# Support
-## End of life dates 
-| Version | Support | End of phase (dd/mm/aaaa) |
-|--|--|--|
-|3.x|Supported|  |
-|2.x|Passively supported|02-06-2029|
-|1.x|End of life process|02-06-2025|
+---
 
-## Support life cycle
-When a new major version (N) is released, it will become actively supported. Bugs will be fixed and new features will be added (new default deletion algorithm, better documentation, etc.).
-The library will be audited every week with the `cargo audit` command to ensure that no flaws persist in the solution.
+## Supported sanitisation standards
 
-The previous major version (N-1) will enter in the passive support phase, which will last 5 years. 
-During this period, the library dependencies will be updated every three months to ensure that the project is running as up-to-date as possible. The code will also be audited, but only on a monthly basis with the `cargo audit`. If a CVE requiring a modification to the library code is discovered, a new minor version will be published. 
+| Variant                  | Standard            | Passes |
+|--------------------------|---------------------|:------:|
+| `Method::PseudoRandom`   | Random data         |   1    |
+| `Method::HmgiS5`         | HMGI S5             |   2    |
+| `Method::Afssi5020`      | AFSSI 5020          |   3    |
+| `Method::Dod522022ME`    | DoD 5220.22-M (ME)  |   3    |
+| `Method::RcmpTssitOpsII` | RCMP TSSIT OPS-II   |   7    |
+| `Method::Dod522022MECE`  | DoD 5220.22-M (ECE) |   7    |
+| `Method::Gutmann`        | Gutmann             |   35   |
 
-Once this passive support phase is over, the version will enter in the end-of-life process, which will last 1 year. During this phase, no more dependencies will be updated and no more issues concerning this library will be taken into account. This phase exists to give projects that may use the library additional time to make the necessary changes to their code before moving the version to ‘Yanked’ on [crates.io](https://crates.io/crates/nozomi/versions)
+See [ERASE_METHOD.md](ERASE_METHOD.md) for a detailed description of each pass schedule.
 
-# Features
-| Features |Explanation   |
-|--|--|
-| error-stack | allows the use of the error-stack library for error handling instead of the standard Rust error handling |
-| log | Allows logs to be used within the library. However, as these logs allow the name of the deleted file / folder to be recovered. |
-| secure_log | Allows you to display logs giving an idea of the progress of the rewriting functions but keeping the overwritten file/folder ‘secret’ by using the md5 hash algorithm. |
+---
 
-# [Changelog](CHANGELOG.md)
-# [Contributing](CONTRIBUTING.md)
+## Optional features
 
-# [Erase Method](ERASE_METHOD.md)
+| Feature       | Description                                                                                             |
+|---------------|---------------------------------------------------------------------------------------------------------|
+| `dry-run`     | Simulate a deletion without writing anything to disk                                                    |
+| `verify`      | Read back the last overwrite pass to confirm it was written correctly                                   |
+| `analyze`     | Inspect the pass schedule of a method before running it                                                 |
+| `log`         | Emit trace-level log entries via the [`log`](https://docs.rs/log) façade                                |
+| `secure_log`  | Like `log`, but replaces file paths with their MD5 hash to avoid leaking names                          |
+| `error-stack` | *(Deprecated — removed in 4.0.0)* Richer error context via [`error-stack`](https://docs.rs/error-stack) |
+
+Enable features in `Cargo.toml`:
+
+```toml
+[dependencies]
+nozomi = { version = "3.1.0", features = ["verify", "dry-run"] }
+```
+
+---
+
+## ⚠ Important notice for SSD users
+
+**Overwrite-based deletion methods are not reliable on solid-state drives.**
+
+On a traditional hard disk drive (HDD), each logical block maps directly to a
+fixed physical location on the platter. Overwriting a block is therefore
+guaranteed to destroy the previous magnetic signal at that exact location.
+
+SSDs work differently. The **Flash Translation Layer (FTL)** abstracts the
+physical NAND cells behind a logical address space and applies **wear leveling**
+— a technique that deliberately spreads writes across all available cells to
+maximise drive longevity. When Nozomi asks the OS to overwrite a file, the FTL
+is free to redirect each write to a *different* set of physical cells, leaving
+the original data intact in unmapped or reserved sectors.
+
+### What this means in practice
+
+| Storage type        | Overwrite-based deletion                           | Reliable? |
+|---------------------|----------------------------------------------------|:---------:|
+| HDD (spinning disk) | Physical sector is rewritten in place              |   ✅ Yes   |
+| SSD / NVMe          | FTL may redirect writes; original cells may remain |   ❌ No    |
+| USB flash drive     | Same FTL / wear leveling constraints as SSD        |   ❌ No    |
+| SD card             | Same FTL / wear leveling constraints as SSD        |   ❌ No    |
+
+### Recommended alternatives for SSDs
+
+- **ATA Secure Erase / NVMe Format** — a drive-level command that instructs the
+  controller to cryptographically erase or reset all cells, including
+  over-provisioned and reserved areas. Supported by most modern drives and
+  exposed by tools such as `hdparm` (Linux) or `nvme-cli`.
+- **Full-disk encryption from the start** — if the drive is encrypted before any
+  sensitive data is written, destroying the encryption key renders all data
+  unrecoverable, regardless of what the FTL has done with the physical cells.
+
+Nozomi is most effective on **HDDs and RAM-backed filesystems** (e.g. `tmpfs`).
+Using it on an SSD will still overwrite the logical blocks visible to the OS,
+which may be sufficient for a low-threat model, but it cannot provide the same
+guarantees as on spinning media.
+
+---
+
+## Support
+
+### Supported versions
+
+| Version | Status              | End of phase |
+|---------|---------------------|--------------|
+| 3.x     | Actively supported  | —            |
+| 2.x     | Passively supported | 02 Jun 2029  |
+| 1.x     | Yanked              | 02 Jun 2025  |
+
+### Support lifecycle
+
+**Active support (current major):** bugs are fixed, new features are added, and
+dependencies are audited weekly with `cargo audit`.
+
+**Passive support (previous major, 5 years):** dependencies are updated every
+three months, `cargo audit` runs monthly. If a CVE requires a code change, a
+new minor version is published.
+
+**End-of-life process (1 year):** no dependency updates, no issue triage. This
+phase gives downstream projects time to migrate before the version is yanked on
+[crates.io](https://crates.io/crates/nozomi/versions).
+
+---
+
+## License
+
+Licensed under either of:
+
+- [MIT](LICENCE-MIT.md)
+- [Apache License, Version 2.0](LICENCE-APACHE.md)
+
+at your option.
+
+---
+
+[Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,111 @@
-# TODO security policy
+# Security Policy
+
+## Overview
+
+Security is a core concern for **Nozomi**.
+
+Because this library performs **irreversible data deletion operations**,
+bugs or unexpected behaviour could lead to data loss or security issues.
+For this reason, security reports are taken seriously.
+
+This document explains how to report vulnerabilities and which versions
+of the project are supported.
+
+------------------------------------------------------------------------
+
+## Supported Versions
+
+The following versions currently receive security support.
+
+| Version | Status             | Security Support                      |
+|---------|--------------------|---------------------------------------|
+| 3.x     | Actively supported | Security fixes and improvements       |
+| 2.x     | Passive support    | Dependency updates and critical fixes |
+| 1.x     | End of life        | No longer supported                   |
+
+
+Passive support versions may receive **critical security fixes or
+dependency updates**, but no new features.
+
+------------------------------------------------------------------------
+
+## Reporting a Vulnerability
+
+If you discover a potential security vulnerability, **please do not open
+a public GitHub issue**.
+
+Instead, report it privately using one of the following methods:
+
+### Preferred method
+
+Open a **GitHub Security Advisory**: https://github.com/Sans-Atout/Nozomi/security/advisories/new
+
+### Alternative
+
+Contact the maintainer privately.
+
+When reporting a vulnerability, please include:
+
+-   a clear description of the issue
+-   steps to reproduce the problem
+-   the potential impact
+-   a proof of concept if available
+
+This helps evaluate and address the issue quickly.
+
+------------------------------------------------------------------------
+
+## Disclosure Process
+
+When a vulnerability is reported, the following process is typically
+followed:
+
+1.  The report is reviewed and validated.
+2.  A fix is developed and tested.
+3.  A security release is prepared if necessary.
+4.  The vulnerability is publicly disclosed with the release notes.
+
+Because this project is maintained during personal time, response times
+may vary.
+
+------------------------------------------------------------------------
+
+## Storage and Filesystem Limitations
+
+Nozomi performs **overwrite-based deletion at the filesystem level**.
+
+Due to the behaviour of modern storage technologies, secure deletion
+cannot be guaranteed in all environments.
+
+Limitations may exist with:
+
+-   SSD wear leveling
+-   journaling filesystems
+-   RAID controllers
+-   filesystem snapshots
+-   network filesystems
+
+For highly sensitive environments, full disk encryption combined with
+cryptographic key destruction may provide stronger guarantees.
+
+------------------------------------------------------------------------
+
+## Cryptographic Considerations
+
+Nozomi does **not provide cryptographic data destruction guarantees**.
+
+Random overwrite passes rely on randomness provided through the Rust
+ecosystem.
+
+The `secure_log` feature hashes identifiers to reduce information
+exposure, but this hashing is **not intended as a cryptographic security
+mechanism**.
+
+------------------------------------------------------------------------
+
+## Responsible Disclosure
+
+If you discover a vulnerability, please allow time for the issue to be
+fixed before publicly disclosing the details.
+
+Responsible disclosure helps protect users of the library.

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1,19 +1,34 @@
+/// Describes the type of data written during a single overwrite pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PassKind {
+    /// The entire pass is filled with `0x00` bytes.
     Zero,
+    /// The entire pass is filled with `0xFF` bytes.
     One,
+    /// The entire pass repeats a single byte value.
     Pattern(u8),
+    /// The entire pass repeats a 3-byte pattern cyclically.
     ThreeBytePattern([u8; 3]),
+    /// The entire pass is filled with cryptographically random bytes.
     Random,
 }
 
+/// Metadata describing a single overwrite pass within a [`Method`](crate::Method).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassInfo {
+    /// The type of data written during this pass.
     pub kind: PassKind,
 }
 
+/// A static description of the overwrite schedule applied by a [`Method`](crate::Method).
+///
+/// Obtained via [`Method::analyze`](crate::Method::analyze) when the `analyze` feature is
+/// enabled. Useful for auditing or displaying the pass plan to the user before
+/// executing a deletion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnalysisReport {
+    /// Total number of overwrite passes that will be performed.
     pub pass_count: usize,
+    /// Ordered list of pass descriptors, one entry per pass.
     pub passes: Vec<PassInfo>,
 }

--- a/src/api/delete/builder.rs
+++ b/src/api/delete/builder.rs
@@ -4,8 +4,6 @@ use std::path::{Path, PathBuf};
 use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
-#[cfg(feature = "error-stack")]
-use error_stack::ResultExt;
 
 use super::request::{DeleteMethod, DeleteRequest};
 
@@ -105,7 +103,7 @@ impl DeleteRequestBuilder {
             path,
             method,
             #[cfg(feature = "dry-run")]
-            dry_run: self.dry_run.clone(),
+            dry_run: self.dry_run,
         })
     }
 }
@@ -115,7 +113,6 @@ mod tests {
     use super::*;
     use crate::Method;
     use crate::api::delete::request::DeleteMethod;
-    use error_stack::Frame;
     use std::path::PathBuf;
 
     #[test]
@@ -137,8 +134,6 @@ mod tests {
 
     #[test]
     fn build_fails_when_method_is_missing() {
-        use std::path::PathBuf;
-
         let result = DeleteRequestBuilder::new()
             .path(PathBuf::from("/tmp/file.txt"))
             .build();
@@ -156,8 +151,6 @@ mod tests {
 
     #[test]
     fn build_succeeds_when_all_parameters_are_present() {
-        use std::path::PathBuf;
-
         let result = DeleteRequestBuilder::new()
             .path(PathBuf::from("/tmp/file.txt"))
             .method(DeleteMethod::BuiltIn(Method::default()))

--- a/src/api/delete/builder.rs
+++ b/src/api/delete/builder.rs
@@ -7,6 +7,23 @@ use crate::{Error, Result};
 
 use super::request::{DeleteMethod, DeleteRequest};
 
+/// A builder for constructing a [`DeleteRequest`] using a fluent API.
+///
+/// All fields are optional during construction, but both `path` and `method`
+/// must be set before calling [`build`](DeleteRequestBuilder::build). Omitting
+/// either will cause `build` to return an [`Error::MissingParameter`].
+///
+/// # Example
+///
+/// ```rust
+/// use nozomi::{DeleteRequest, DeleteMethod, Method};
+///
+/// let request = DeleteRequest::builder()
+///     .path("/path/to/sensitive/file.txt")
+///     .method(DeleteMethod::BuiltIn(Method::Gutmann))
+///     .build()
+///     .expect("failed to build delete request");
+/// ```
 #[derive(Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct DeleteRequestBuilder {
@@ -17,20 +34,34 @@ pub struct DeleteRequestBuilder {
 }
 
 impl DeleteRequestBuilder {
+    /// Creates a new builder with all fields unset.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the filesystem path of the file to be securely deleted.
+    ///
+    /// The path is accepted as any type that implements [`AsRef<Path>`],
+    /// including `&str`, `String`, and [`PathBuf`].
     pub fn path<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.path = Some(path.as_ref().to_path_buf());
         self
     }
 
+    /// Sets the overwrite method to apply during secure deletion.
+    ///
+    /// See [`DeleteMethod`] for available variants and [`Method`](crate::Method)
+    /// for the list of built-in sanitisation standards.
     pub fn method(mut self, method: DeleteMethod) -> Self {
         self.method = Some(method);
         self
     }
 
+    /// Controls whether the deletion runs in dry-run mode.
+    ///
+    /// When `dry_run` is `true`, the engine simulates the deletion pipeline
+    /// without performing any write operations on disk. This is useful for
+    /// verifying configuration and observing emitted events without risk.
     #[cfg(feature = "dry-run")]
     pub fn dry_run(mut self, dry_run: bool) -> Self {
         self.dry_run = dry_run;
@@ -40,6 +71,11 @@ impl DeleteRequestBuilder {
 
 #[cfg(not(feature = "error-stack"))]
 impl DeleteRequestBuilder {
+    /// Validates the builder state and constructs a [`DeleteRequest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MissingParameter`] if `path` or `method` has not been set.
     pub fn build(self) -> Result<DeleteRequest> {
         let path = self.path.ok_or(Error::MissingParameter("path"))?;
 
@@ -96,6 +132,12 @@ mod tests {
 
 #[cfg(feature = "error-stack")]
 impl DeleteRequestBuilder {
+    /// Validates the builder state and constructs a [`DeleteRequest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`error_stack::Report`] wrapping [`Error::MissingParameter`]
+    /// if `path` or `method` has not been set.
     pub fn build(self) -> Result<DeleteRequest> {
         let path = self.path.ok_or(Error::MissingParameter("path"))?;
         let method = self.method.ok_or(Error::MissingParameter("method"))?;

--- a/src/api/delete/legacy.rs
+++ b/src/api/delete/legacy.rs
@@ -2,6 +2,21 @@ use crate::SecureDelete;
 
 use super::builder::DeleteRequestBuilder;
 
+/// Converts a [`SecureDelete`] into a [`DeleteRequestBuilder`], preserving the
+/// file path.
+///
+/// This implementation provides a migration path from the deprecated
+/// [`SecureDelete`] API to the current builder-based API. The resulting builder
+/// still requires a [`method`](DeleteRequestBuilder::method) to be set before
+/// [`build`](DeleteRequestBuilder::build) can succeed.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // SecureDelete is deprecated — use DeleteRequestBuilder directly for new code.
+/// let builder = DeleteRequestBuilder::from(legacy_secure_delete);
+/// let request = builder.method(DeleteMethod::BuiltIn(Method::PseudoRandom)).build()?;
+/// ```
 impl From<SecureDelete> for DeleteRequestBuilder {
     fn from(sd: SecureDelete) -> Self {
         DeleteRequestBuilder::new().path(sd.path)

--- a/src/api/delete/legacy.rs
+++ b/src/api/delete/legacy.rs
@@ -21,7 +21,7 @@ mod tests {
     #[cfg(feature = "error-stack")]
     use crate::Result;
     #[cfg(feature = "error-stack")]
-    use error_stack::{Report, ResultExt};
+    use error_stack::ResultExt;
 
     #[test]
     #[cfg(not(feature = "error-stack"))]

--- a/src/api/delete/mod.rs
+++ b/src/api/delete/mod.rs
@@ -1,3 +1,34 @@
+//! High-level API for scheduling and executing secure file deletion.
+//!
+//! This module exposes the primary entry points for consumers of the library.
+//! The recommended workflow is to construct a [`DeleteRequest`] via
+//! [`DeleteRequestBuilder`], then call [`DeleteRequest::run`] (or
+//! [`DeleteRequest::run_with`] to receive structured progress events).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use nozomi::{DeleteRequest, DeleteMethod, Method};
+//!
+//! let report = DeleteRequest::builder()
+//!     .path("/path/to/sensitive/file.txt")
+//!     .method(DeleteMethod::BuiltIn(Method::Gutmann))
+//!     .build()?
+//!     .run()?;
+//!
+//! println!("Securely deleted {:?} using {}", report.path, report.method);
+//! # Ok::<(), nozomi::Error>(())
+//! ```
+//!
+//! ## Submodules
+//!
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`builder`] | Fluent builder for [`DeleteRequest`] |
+//! | [`report`]  | Result type returned after a successful deletion |
+//! | [`request`] | Core request type and deletion method selector |
+//! | [`legacy`]  | Compatibility bridges for the deprecated [`SecureDelete`](crate::SecureDelete) API |
+
 pub mod builder;
 pub mod legacy;
 pub mod report;

--- a/src/api/delete/report.rs
+++ b/src/api/delete/report.rs
@@ -1,8 +1,16 @@
 use crate::Method;
 use std::path::PathBuf;
 
+/// A summary of a completed secure deletion operation.
+///
+/// `DeleteReport` is returned by [`DeleteRequest::run`](super::request::DeleteRequest::run)
+/// and [`DeleteRequest::run_with`](super::request::DeleteRequest::run_with) upon success.
+/// It records which file was targeted and which sanitisation standard was applied,
+/// making it suitable for audit logging.
 #[derive(Debug, Clone)]
 pub struct DeleteReport {
+    /// Absolute path of the file that was securely deleted.
     pub path: PathBuf,
+    /// Overwrite method that was applied during the deletion.
     pub method: Method,
 }

--- a/src/api/delete/request.rs
+++ b/src/api/delete/request.rs
@@ -9,6 +9,15 @@ use crate::engine::emit_safe;
 use crate::{DeleteEvent, EventSink, Method};
 use std::path::PathBuf;
 
+/// A fully validated request to securely delete a file.
+///
+/// Instances are constructed exclusively through [`DeleteRequestBuilder`] to
+/// guarantee that all required fields are present before execution begins.
+/// Once built, a request is immutable and can be executed via [`run`] or
+/// [`run_with`].
+///
+/// [`run`]: DeleteRequest::run
+/// [`run_with`]: DeleteRequest::run_with
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct DeleteRequest {
@@ -18,13 +27,21 @@ pub struct DeleteRequest {
     pub(crate) dry_run: bool,
 }
 
+/// Specifies the overwrite strategy to apply during secure deletion.
+///
+/// Currently the only variant is [`BuiltIn`](DeleteMethod::BuiltIn), which
+/// delegates to one of the standards defined in [`Method`]. Additional
+/// variants (e.g., custom strategies) may be added in future releases.
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum DeleteMethod {
+    /// One of the built-in, standards-compliant overwrite methods.
     BuiltIn(Method),
 }
 
 impl DeleteRequest {
+    /// Creates a new [`DeleteRequestBuilder`] as the entry point for
+    /// constructing a `DeleteRequest`.
     pub fn builder() -> DeleteRequestBuilder {
         DeleteRequestBuilder::new()
     }
@@ -32,11 +49,37 @@ impl DeleteRequest {
 
 #[cfg(not(feature = "error-stack"))]
 impl DeleteRequest {
+    /// Executes the secure deletion pipeline and returns a [`DeleteReport`] on success.
+    ///
+    /// This is the zero-overhead convenience wrapper around [`run_with`]. It discards
+    /// all progress events. Use [`run_with`] instead if you need to observe or log
+    /// individual deletion steps.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] if the target path cannot be opened, overwritten,
+    /// or removed.
+    ///
+    /// [`run_with`]: DeleteRequest::run_with
     pub fn run(&self) -> Result<DeleteReport> {
         let mut sink = NoopSink;
         self.run_with(&mut sink)
     }
 
+    /// Executes the secure deletion pipeline, forwarding structured events to `sink`.
+    ///
+    /// Each step of the overwrite process emits a [`DeleteEvent`] through the
+    /// provided [`EventSink`], enabling progress tracking, audit logging, or
+    /// integration with external monitoring systems.
+    ///
+    /// When the `dry-run` feature is enabled and [`dry_run`](super::builder::DeleteRequestBuilder::dry_run)
+    /// is set to `true`, the pipeline is simulated: events are emitted but no
+    /// data is written to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] if the target path cannot be opened, overwritten,
+    /// or removed.
     pub fn run_with<S: EventSink>(&self, sink: &mut S) -> Result<DeleteReport> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -77,11 +120,37 @@ impl DeleteRequest {
 
 #[cfg(feature = "error-stack")]
 impl DeleteRequest {
+    /// Executes the secure deletion pipeline and returns a [`DeleteReport`] on success.
+    ///
+    /// This is the zero-overhead convenience wrapper around [`run_with`]. It discards
+    /// all progress events. Use [`run_with`] instead if you need to observe or log
+    /// individual deletion steps.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`error_stack::Report`] wrapping [`Error`] if the target path
+    /// cannot be opened, overwritten, or removed.
+    ///
+    /// [`run_with`]: DeleteRequest::run_with
     pub fn run(&self) -> Result<DeleteReport> {
         let mut sink = NoopSink;
         self.run_with(&mut sink)
     }
 
+    /// Executes the secure deletion pipeline, forwarding structured events to `sink`.
+    ///
+    /// Each step of the overwrite process emits a [`DeleteEvent`] through the
+    /// provided [`EventSink`], enabling progress tracking, audit logging, or
+    /// integration with external monitoring systems.
+    ///
+    /// When the `dry-run` feature is enabled and [`dry_run`](super::builder::DeleteRequestBuilder::dry_run)
+    /// is set to `true`, the pipeline is simulated: events are emitted but no
+    /// data is written to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`error_stack::Report`] wrapping [`Error`] if the target path
+    /// cannot be opened, overwritten, or removed.
     pub fn run_with<S: EventSink>(&self, sink: &mut S) -> Result<DeleteReport> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -120,6 +189,10 @@ impl DeleteRequest {
     }
 }
 
+/// An [`EventSink`] that silently discards every emitted event.
+///
+/// Used internally by [`DeleteRequest::run`] to avoid requiring callers to
+/// supply a sink when event observation is not needed.
 pub(crate) struct NoopSink;
 
 impl EventSink for NoopSink {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,6 @@
+//! Public API surface for the Nozomi library.
+//!
+//! This module re-exports the top-level types that consumers interact with.
+//! For the full deletion workflow, see the [`delete`] submodule.
+
 pub mod delete;

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -1,30 +1,70 @@
 use std::path::PathBuf;
 
-/// Structured execution events emitted during deletion.
+/// Structured execution events emitted during a deletion run.
+///
+/// Implementations of [`EventSink`] receive these events in order as the
+/// engine progresses. The sequence for a normal (non-dry-run) deletion is:
+///
+/// 1. [`DeletionStarted`](DeleteEvent::DeletionStarted)
+/// 2. [`EntryOverwritePass`](DeleteEvent::EntryOverwritePass) × N (once per pass, per file)
+/// 3. [`EntryDeleted`](DeleteEvent::EntryDeleted) × M (once per file, then once per directory)
+/// 4. [`DeletionFinished`](DeleteEvent::DeletionFinished)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeleteEvent {
-    /// Deletion process has started for a given path
+    /// The deletion pipeline has started for the entry at `path`.
     DeletionStarted { path: PathBuf },
-    /// A filesystem entry has been successfully overwritten
+
+    /// A single overwrite pass has completed for the entry at `path`.
     EntryOverwritePass {
+        /// Path of the file being overwritten.
         path: PathBuf,
+        /// 1-based index of the pass that just completed.
         pass: u32,
+        /// Total number of passes scheduled for this file.
         total_passes: u32,
     },
 
-    /// A filesystem entry has been successfully deleted
+    /// A file or directory has been successfully removed from the filesystem.
     EntryDeleted { path: PathBuf },
 
-    /// Deletion process has finished
+    /// The deletion pipeline has finished for the entry at `path`.
+    ///
+    /// This event is always emitted, even if an earlier step failed, so
+    /// consumers can reliably use it as a completion signal.
     DeletionFinished { path: PathBuf },
+
+    /// Post-overwrite byte verification has started for the entry at `path`.
+    ///
+    /// Only emitted when the `verify` feature is enabled.
     #[cfg(feature = "verify")]
     VerificationStarted { path: PathBuf },
+
+    /// Post-overwrite byte verification succeeded for the entry at `path`.
+    ///
+    /// Only emitted when the `verify` feature is enabled.
     #[cfg(feature = "verify")]
     VerificationCompleted { path: PathBuf },
+
+    /// Post-overwrite byte verification detected an unexpected byte at `offset`.
+    ///
+    /// Only emitted when the `verify` feature is enabled.
     #[cfg(feature = "verify")]
-    VerificationFailed { path: PathBuf, offset: u64 },
+    VerificationFailed {
+        /// Path of the file whose verification failed.
+        path: PathBuf,
+        /// Byte offset of the first mismatched byte within the file.
+        offset: u64,
+    },
+
+    /// A dry-run deletion simulation has started for the entry at `path`.
+    ///
+    /// Only emitted when the `dry-run` feature is enabled.
     #[cfg(feature = "dry-run")]
     DryRunStarted { path: PathBuf },
+
+    /// A dry-run deletion simulation has completed for the entry at `path`.
+    ///
+    /// Only emitted when the `dry-run` feature is enabled.
     #[cfg(feature = "dry-run")]
     DryRunCompleted { path: PathBuf },
 }

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -11,6 +11,16 @@ use crate::Result;
 #[cfg(feature = "error-stack")]
 use crate::Result;
 
+/// Executes the full secure deletion pipeline for the entry at `path`.
+///
+/// The engine builds an [`ExecutionPlan`](super::planner::ExecutionPlan), overwrites
+/// every file in the plan using the chosen `method`, deletes each file, and
+/// finally removes empty directories in reverse order. Progress events are
+/// forwarded to `sink` throughout.
+///
+/// # Errors
+///
+/// Returns an error if any overwrite pass, file deletion, or directory removal fails.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(
@@ -59,6 +69,18 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> R
     result
 }
 
+/// Simulates the secure deletion pipeline without performing any write or
+/// delete operations on disk.
+///
+/// The engine builds an execution plan and emits the same events as [`run`],
+/// but no bytes are written and no files are removed. Useful for verifying
+/// configuration and observing expected event sequences.
+///
+/// Only available when the `dry-run` feature is enabled.
+///
+/// # Errors
+///
+/// Returns an error if the execution plan cannot be built (e.g. path not found).
 #[cfg(all(feature = "dry-run", not(feature = "error-stack")))]
 pub(crate) fn dry_run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(
@@ -103,6 +125,17 @@ pub(crate) fn dry_run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) 
     result
 }
 
+/// Executes the full secure deletion pipeline for the entry at `path`.
+///
+/// The engine builds an [`ExecutionPlan`](super::planner::ExecutionPlan), overwrites
+/// every file in the plan using the chosen `method`, deletes each file, and
+/// finally removes empty directories in reverse order. Progress events are
+/// forwarded to `sink` throughout.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if any
+/// overwrite pass, file deletion, or directory removal fails.
 #[cfg(feature = "error-stack")]
 pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(
@@ -151,6 +184,19 @@ pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> R
     result
 }
 
+/// Simulates the secure deletion pipeline without performing any write or
+/// delete operations on disk.
+///
+/// The engine builds an execution plan and emits the same events as [`run`],
+/// but no bytes are written and no files are removed. Useful for verifying
+/// configuration and observing expected event sequences.
+///
+/// Only available when the `dry-run` feature is enabled.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if the
+/// execution plan cannot be built (e.g. path not found).
 #[cfg(all(feature = "dry-run", feature = "error-stack"))]
 pub(crate) fn dry_run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {
     emit_safe(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -9,12 +9,7 @@ use crate::engine::utils::{delete_dir, delete_file, emit_safe};
 use crate::Result;
 
 #[cfg(feature = "error-stack")]
-use crate::{Error, Result};
-#[cfg(feature = "error-stack")]
-use error_stack::ResultExt;
-
-#[cfg(feature = "log")]
-use log::info;
+use crate::Result;
 
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn run<S: EventSink>(method: &Method, path: &Path, sink: &mut S) -> Result<()> {

--- a/src/engine/overwrite/afssi_5020.rs
+++ b/src/engine/overwrite/afssi_5020.rs
@@ -30,14 +30,16 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
 // -- Region : AFSSI 5020 overwriting method for basic error handling method
 
-/// Function that implement [AFSSI 5020 overwrite method](https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [AFSSI 5020](https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020)
+/// sanitisation standard (3 passes: `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using AFSSI 5020 overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -93,6 +95,11 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the AFSSI 5020 overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as
+/// [`overwrite_file`] so that event-driven code behaves identically in dry-run
+/// mode. Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -113,14 +120,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement [AFSSI 5020 overwrite method](https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [AFSSI 5020](https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020)
+/// sanitisation standard (3 passes: `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using AFSSI 5020 overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -175,6 +184,11 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the AFSSI 5020 overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as
+/// [`overwrite_file`] so that event-driven code behaves identically in dry-run
+/// mode. Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/afssi_5020.rs
+++ b/src/engine/overwrite/afssi_5020.rs
@@ -1,6 +1,6 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::RngCore;
+use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -23,8 +23,8 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 use crate::engine::utils::emit_safe;
-#[cfg(feature = "log")]
-use log::info;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -96,7 +96,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
@@ -178,8 +178,8 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
-    for (pass, patterns) in FIXED_PATTERNS.iter().enumerate() {
+    let seed = [0u8; 32];
+    for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -190,7 +190,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         );
     }
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
     Ok(())
 }
 
@@ -200,7 +200,6 @@ mod test {
     use crate::Method::Afssi5020 as EraseMethod;
     const METHOD_NAME: &str = "afssi_5020";
 
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -208,8 +207,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -217,6 +216,9 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -379,8 +381,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -390,6 +392,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/common.rs
+++ b/src/engine/overwrite/common.rs
@@ -16,6 +16,16 @@ use error_stack::ResultExt;
 
 use crate::engine::utils::generate_seed;
 
+/// Opens the file at `path` for reading and writing, queries its size, rewinds
+/// the cursor to the start, and returns a fresh CSPRNG seeded with random
+/// entropy alongside a zeroed 8 KiB write buffer.
+///
+/// This setup is shared by all overwrite method implementations.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened, its metadata cannot be read,
+/// or the cursor cannot be rewound.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn prepare_overwrite(path: &Path) -> Result<(std::fs::File, u64, StdRng, [u8; 8192])> {
     let mut file = OpenOptions::new()
@@ -47,6 +57,17 @@ pub(crate) fn prepare_overwrite(path: &Path) -> Result<(std::fs::File, u64, StdR
     Ok((file, file_size, rng, buffer))
 }
 
+/// Opens the file at `path` for reading and writing, queries its size, rewinds
+/// the cursor to the start, and returns a fresh CSPRNG seeded with random
+/// entropy alongside a zeroed 8 KiB write buffer.
+///
+/// This setup is shared by all overwrite method implementations.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if the
+/// file cannot be opened, its metadata cannot be read, or the cursor cannot be
+/// rewound.
 #[cfg(feature = "error-stack")]
 pub(crate) fn prepare_overwrite(path: &Path) -> Result<(std::fs::File, u64, StdRng, [u8; 8192])> {
     let mut file = OpenOptions::new()

--- a/src/engine/overwrite/common.rs
+++ b/src/engine/overwrite/common.rs
@@ -15,8 +15,6 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 use crate::engine::utils::generate_seed;
-#[cfg(feature = "log")]
-use log::info;
 
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn prepare_overwrite(path: &Path) -> Result<(std::fs::File, u64, StdRng, [u8; 8192])> {

--- a/src/engine/overwrite/dod_522022_me.rs
+++ b/src/engine/overwrite/dod_522022_me.rs
@@ -29,14 +29,16 @@ const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
 // -- Region : DOD 522 022 ME overwriting method for basic error handling method
 
-/// Function that implement [DOD 522022 ME overwrite method](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [DoD 5220.22-M (ME)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
+/// sanitisation standard (3 passes: `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using DOD 522 022 ME overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -91,6 +93,11 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the DoD 5220.22-M (ME) overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as
+/// [`overwrite_file`] so that event-driven code behaves identically in dry-run
+/// mode. Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -110,14 +117,17 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
 
     Ok(())
 }
-/// Function that implement [DOD 522022 ME overwrite method](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [DoD 5220.22-M (ME)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
+/// sanitisation standard (3 passes: `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using DOD 522 022 ME overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if any
+/// write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -173,6 +183,11 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the DoD 5220.22-M (ME) overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as
+/// [`overwrite_file`] so that event-driven code behaves identically in dry-run
+/// mode. Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/dod_522022_me.rs
+++ b/src/engine/overwrite/dod_522022_me.rs
@@ -1,6 +1,6 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::RngCore;
+use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -22,8 +22,8 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 use crate::engine::utils::emit_safe;
-#[cfg(feature = "log")]
-use log::info;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 
 const FIXED_PATTERNS: &[Option<u8>] = &[Some(0x00), Some(0xFF), None];
 
@@ -94,7 +94,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
@@ -176,7 +176,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
@@ -188,7 +188,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         );
     }
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
 
     Ok(())
 }
@@ -198,8 +198,6 @@ mod test {
     use crate::Method::Dod522022ME as EraseMethod;
     const METHOD_NAME: &str = "dod_522022_me";
 
-    use super::overwrite_file;
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -207,8 +205,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::{Result};
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -216,6 +214,10 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -375,8 +377,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -385,6 +387,10 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
+            use crate::engine::overwrite::dod_522022_me::overwrite_file;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/dod_522022_mece.rs
+++ b/src/engine/overwrite/dod_522022_mece.rs
@@ -1,6 +1,6 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::RngCore;
+use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -14,11 +14,11 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 use crate::engine::utils::emit_safe;
-#[cfg(feature = "log")]
-use log::info;
 
 #[cfg(feature = "verify")]
 use crate::engine::utils::generate_seed;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
 #[cfg(feature = "verify")]
@@ -105,7 +105,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
@@ -189,7 +189,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for (pass, _) in FIXED_PATTERNS.iter().enumerate() {
         emit_safe(
             sink,
@@ -201,7 +201,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         );
     }
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
 
     Ok(())
 }
@@ -211,8 +211,6 @@ mod test {
     const METHOD_NAME: &str = "dod_522022_mece";
     use crate::Method::Dod522022MECE as EraseMethod;
 
-    use super::overwrite_file;
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -220,8 +218,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -229,6 +227,10 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::engine::overwrite::dod_522022_mece::overwrite_file;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -388,8 +390,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -399,6 +401,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/dod_522022_mece.rs
+++ b/src/engine/overwrite/dod_522022_mece.rs
@@ -38,14 +38,16 @@ const FIXED_PATTERNS: &[Option<u8>] = &[
 
 // -- Region : DOD 522 022 MECE overwriting method for basic error handling method
 
-/// Function that implement [DOD 522022 MECE overwrite method](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [DoD 5220.22-M (ECE)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
+/// sanitisation standard (7 passes: `0x00`, `0xFF`, random, `0x00`, `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using DOD 522022 MECE overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `secure_deletion` (SecureDelete) : An SecureDelete object
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -102,6 +104,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the DoD 5220.22-M (ECE) overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -122,14 +128,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement [DOD 522022 MECE overwrite method](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [DoD 5220.22-M (ECE)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php)
+/// sanitisation standard (7 passes: `0x00`, `0xFF`, random, `0x00`, `0x00`, `0xFF`, random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using DOD 522022 MECE overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `secure_deletion` (SecureDelete) : An SecureDelete object
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -186,6 +194,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the DoD 5220.22-M (ECE) overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/gutmann.rs
+++ b/src/engine/overwrite/gutmann.rs
@@ -56,14 +56,16 @@ const FIXED_PATTERNS: &[[u8; 3]] = &[
     [0xDB, 0x6D, 0xB6],
 ];
 
-/// Function that implement [Gutmann overwrite method](https://en.wikipedia.org/wiki/Gutmann_method)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [Gutmann](https://en.wikipedia.org/wiki/Gutmann_method) sanitisation
+/// standard (35 passes: 4 random, 27 fixed 3-byte patterns, 4 random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using basic pseudo random method overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -127,6 +129,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the Gutmann overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -147,14 +153,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement [Gutmann overwrite method](https://en.wikipedia.org/wiki/Gutmann_method)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [Gutmann](https://en.wikipedia.org/wiki/Gutmann_method) sanitisation
+/// standard (35 passes: 4 random, 27 fixed 3-byte patterns, 4 random).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using basic pseudo random method overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, mut rng, mut buffer) = prepare_overwrite(path)?;
@@ -216,6 +224,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the Gutmann overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/gutmann.rs
+++ b/src/engine/overwrite/gutmann.rs
@@ -1,6 +1,6 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::RngCore;
+use rand::Rng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -14,11 +14,11 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 use crate::engine::utils::emit_safe;
-#[cfg(feature = "log")]
-use log::info;
 
 #[cfg(feature = "verify")]
 use crate::engine::utils::generate_seed;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
 #[cfg(feature = "verify")]
@@ -121,7 +121,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     #[cfg(feature = "verify")]
     verify_last_pass(
         &path.to_path_buf(),
-        crate::engine::verify::LastPassInfo::Random { seed },
+        LastPassInfo::Random { seed },
         sink,
     )?;
     Ok(())
@@ -130,7 +130,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for pass in 0..35 {
         emit_safe(
             sink,
@@ -219,7 +219,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for pass in 0..35 {
         emit_safe(
             sink,
@@ -231,7 +231,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         );
     }
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
 
     Ok(())
 }
@@ -241,7 +241,6 @@ mod test {
     const METHOD_NAME: &str = "gutmann";
     use crate::Method::Gutmann as EraseMethod;
 
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -249,8 +248,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -258,6 +257,9 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -420,8 +422,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -431,6 +433,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/hmgi_s5.rs
+++ b/src/engine/overwrite/hmgi_s5.rs
@@ -13,10 +13,10 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 use crate::engine::utils::emit_safe;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
-#[cfg(feature = "log")]
-use log::info;
 
 /// Function that implement [HMGI S5 overwrite method](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
 /// ! Please note that this method does not delete the given file.
@@ -136,7 +136,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         );
     }
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Zero, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Zero, sink)?;
 
     Ok(())
 }
@@ -147,7 +147,6 @@ mod test {
     const METHOD_NAME: &str = "hmgi_S5";
     use crate::Method::HmgiS5 as EraseMethod;
 
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -155,8 +154,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate:: Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -164,6 +163,9 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -326,8 +328,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::Result;
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -337,6 +339,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/hmgi_s5.rs
+++ b/src/engine/overwrite/hmgi_s5.rs
@@ -18,14 +18,16 @@ use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
 
-/// Function that implement [HMGI S5 overwrite method](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [HMGI S5](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
+/// sanitisation standard (2 passes, both with `0x00`).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using HMGI S5 overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
@@ -61,6 +63,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the HMGI S5 overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     for pattern in 0..2 {
@@ -79,14 +85,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement [HMGI S5 overwrite method](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [HMGI S5](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php)
+/// sanitisation standard (2 passes, both with `0x00`).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using HMGI S5 overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
@@ -123,6 +131,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the HMGI S5 overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     for pattern in 0..2 {

--- a/src/engine/overwrite/mod.rs
+++ b/src/engine/overwrite/mod.rs
@@ -15,9 +15,7 @@ use std::path::Path;
 use crate::Result;
 
 #[cfg(feature = "error-stack")]
-use crate::{Error, Result};
-#[cfg(feature = "error-stack")]
-use error_stack::ResultExt;
+use crate::Result;
 
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(

--- a/src/engine/overwrite/mod.rs
+++ b/src/engine/overwrite/mod.rs
@@ -1,3 +1,9 @@
+//! Method dispatcher for the overwrite engine.
+//!
+//! Each submodule implements a specific sanitisation standard. This module
+//! provides a single [`overwrite_file`] entry point that routes to the correct
+//! implementation based on the chosen [`Method`].
+
 // -- Region : Module export
 mod afssi_5020;
 mod common;
@@ -17,6 +23,16 @@ use crate::Result;
 #[cfg(feature = "error-stack")]
 use crate::Result;
 
+/// Overwrites the file at `path` using the algorithm specified by `method`,
+/// forwarding progress events to `sink`.
+///
+/// This is the single dispatch point used by the executor. Each method
+/// submodule owns the concrete pass implementation.
+///
+/// # Errors
+///
+/// Returns an error if any overwrite pass fails (I/O error or permission
+/// denied).
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(
     method: &Method,
@@ -35,6 +51,15 @@ pub(crate) fn overwrite_file<S: EventSink>(
     Ok(())
 }
 
+/// Simulates the overwrite of the file at `path` without writing any data,
+/// forwarding the same events as [`overwrite_file`] to `sink`.
+///
+/// Only available when the `dry-run` feature is enabled.
+///
+/// # Errors
+///
+/// Returns an error if the execution context cannot be prepared (e.g. the file
+/// is inaccessible).
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(
     method: &Method,
@@ -53,6 +78,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(
     Ok(())
 }
 
+/// Overwrites the file at `path` using the algorithm specified by `method`,
+/// forwarding progress events to `sink`.
+///
+/// This is the single dispatch point used by the executor. Each method
+/// submodule owns the concrete pass implementation.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if any
+/// overwrite pass fails (I/O error or permission denied).
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(
     method: &Method,
@@ -71,6 +106,15 @@ pub(crate) fn overwrite_file<S: EventSink>(
     Ok(())
 }
 
+/// Simulates the overwrite of the file at `path` without writing any data,
+/// forwarding the same events as [`overwrite_file`] to `sink`.
+///
+/// Only available when the `dry-run` feature is enabled.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if the
+/// execution context cannot be prepared.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(
     method: &Method,

--- a/src/engine/overwrite/pseudo_random.rs
+++ b/src/engine/overwrite/pseudo_random.rs
@@ -1,6 +1,8 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::RngCore;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::io::Write;
 use std::path::Path;
 
@@ -13,15 +15,16 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::ResultExt;
 
-use crate::engine::utils::emit_safe;
 #[cfg(feature = "log")]
 use log::info;
 
+use crate::engine::utils::emit_safe;
+
 use crate::engine::utils::generate_seed;
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
-use rand::SeedableRng;
-use rand::rngs::StdRng;
 
 /// Function that implement a basic pseudo random method using basic error handling method.
 /// ! Please note that this method does not delete the given file.
@@ -82,7 +85,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     emit_safe(
         sink,
         DeleteEvent::EntryOverwritePass {
@@ -157,7 +160,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     emit_safe(
         sink,
         DeleteEvent::EntryOverwritePass {
@@ -167,7 +170,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
         },
     );
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
 
     Ok(())
 }
@@ -178,7 +181,6 @@ mod test {
     const METHOD_NAME: &str = "pseudo_random";
     use crate::Method::PseudoRandom as EraseMethod;
 
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -186,8 +188,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::{Result};
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -195,6 +197,9 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -357,8 +362,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::{Result};
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -368,6 +373,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/overwrite/pseudo_random.rs
+++ b/src/engine/overwrite/pseudo_random.rs
@@ -26,14 +26,15 @@ use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
 
-/// Function that implement a basic pseudo random method using basic error handling method.
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` with a single pass of cryptographically
+/// seeded pseudo-random data.
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using basic pseudo random method overwrite method
+/// This is the fastest built-in method (1 pass). It does **not** delete the
+/// file; deletion is handled by the executor after the pass completes.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if the write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
@@ -82,6 +83,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the pseudo-random overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] event as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -100,14 +105,15 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement a basic pseudo random method using basic error handling method.
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` with a single pass of cryptographically
+/// seeded pseudo-random data.
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using basic pseudo random method overwrite method
+/// This is the fastest built-in method (1 pass). It does **not** delete the
+/// file; deletion is handled by the executor after the pass completes.
 ///
-/// ## Return
-/// * `()`
+/// # Errors
+///
+/// Returns an error if the write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "secure_log")]
@@ -157,6 +163,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the pseudo-random overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] event as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/rcmp_tssit_ops_ii.rs
+++ b/src/engine/overwrite/rcmp_tssit_ops_ii.rs
@@ -23,14 +23,16 @@ use crate::engine::verify::{LastPassInfo, verify_last_pass};
 
 const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 
-/// Function that implement [RCMP TSSIT OPS II overwrite method](https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html) using basic error handling method.
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [RCMP TSSIT OPS-II](https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html)
+/// sanitisation standard (7 passes: 6 alternating `0x00`/`0xFF` passes then 1 random pass).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using RCMP TSSIT OPS II overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
@@ -94,6 +96,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the RCMP TSSIT OPS-II overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
@@ -115,14 +121,16 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     Ok(())
 }
 
-/// Function that implement [RCMP TSSIT OPS II overwrite method](https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html) using basic error handling method.
-/// ! Please note that this method does not delete the given file.
+/// Overwrites the file at `path` using the
+/// [RCMP TSSIT OPS-II](https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html)
+/// sanitisation standard (7 passes: 6 alternating `0x00`/`0xFF` passes then 1 random pass).
 ///
-/// ## Argument :
-/// * `path` (&Path) : path that you want to erase using RCMP TSSIT OPS II overwrite method
+/// This function overwrites the file contents only; it does **not** delete
+/// the file. Deletion is handled by the executor after all passes complete.
 ///
-/// ## Return
-/// * `()
+/// # Errors
+///
+/// Returns an error if any write pass fails or the file cannot be synced.
 #[cfg(feature = "error-stack")]
 pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     let (mut file, file_size, _, mut buffer) = prepare_overwrite(path)?;
@@ -186,6 +194,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     Ok(())
 }
 
+/// Simulates the RCMP TSSIT OPS-II overwrite of `path` without writing any data.
+///
+/// Emits the same [`DeleteEvent::EntryOverwritePass`] events as [`overwrite_file`].
+/// Only available when the `dry-run` feature is enabled.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]

--- a/src/engine/overwrite/rcmp_tssit_ops_ii.rs
+++ b/src/engine/overwrite/rcmp_tssit_ops_ii.rs
@@ -1,6 +1,8 @@
 use crate::engine::overwrite::common::prepare_overwrite;
 use crate::{DeleteEvent, EventSink, Method};
-use rand::{Rng, SeedableRng};
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -14,11 +16,10 @@ use crate::{Error, Result};
 use error_stack::ResultExt;
 
 use crate::engine::utils::{emit_safe, generate_seed};
+#[cfg(all(feature = "verify", feature = "dry-run"))]
+use crate::engine::verify::dry_verify_last_pass;
 #[cfg(feature = "verify")]
 use crate::engine::verify::{LastPassInfo, verify_last_pass};
-#[cfg(feature = "log")]
-use log::info;
-use rand::prelude::StdRng;
 
 const FIXED_PATTERNS: &[u8; 6] = &[0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF];
 
@@ -67,7 +68,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     let mut rng = StdRng::from_seed(seed);
 
     while remaining > 0 {
-        rng.fill(&mut buffer);
+        rng.fill_bytes(&mut buffer);
         let write_size = std::cmp::min(remaining, buffer.len() as u64) as usize;
         file.write_all(&buffer[..write_size])
             .map_err(|_| Error::OverwriteError(Method::RcmpTssitOpsII, 7))?;
@@ -96,7 +97,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for pass in 0..7 {
         emit_safe(
             sink,
@@ -158,7 +159,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
     let seed = generate_seed();
     let mut rng = StdRng::from_seed(seed);
     while remaining > 0 {
-        rng.fill(&mut buffer);
+        rng.fill_bytes(&mut buffer);
         let write_size = std::cmp::min(remaining, buffer.len() as u64) as usize;
         file.write_all(&buffer[..write_size])
             .change_context(Error::OverwriteError(Method::RcmpTssitOpsII, 7))?;
@@ -188,7 +189,7 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<()> {
     #[cfg(feature = "verify")]
-    let mut seed = [0u8; 32];
+    let seed = [0u8; 32];
     for pass in 0..7 {
         emit_safe(
             sink,
@@ -201,7 +202,7 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Res
     }
 
     #[cfg(feature = "verify")]
-    dry_verify_last_pass(&path.to_path_buf(), LastPassInfo::Random { seed }, sink)?;
+    dry_verify_last_pass(path, LastPassInfo::Random { seed }, sink)?;
 
     Ok(())
 }
@@ -212,7 +213,6 @@ mod test {
     const METHOD_NAME: &str = "rcmp_tssit_ops_ii";
     use crate::Method::RcmpTssitOpsII as EraseMethod;
 
-    use crate::error::FSProblem;
     use crate::tests::TestType;
 
     /// Module containing all the tests for the standard error handling method
@@ -220,8 +220,8 @@ mod test {
     mod standard {
         use super::*;
 
-        use crate::tests::standard::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::standard::{create_test_file};
+        use crate::{Result};
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -229,6 +229,9 @@ mod test {
             use crate::api::delete::request::NoopSink;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::standard::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///
@@ -391,8 +394,8 @@ mod test {
     mod enhanced {
         use super::*;
 
-        use crate::tests::enhanced::{create_test_file, get_bytes};
-        use crate::{Error, Result};
+        use crate::tests::enhanced::{create_test_file};
+        use crate::{Result};
 
         #[cfg(not(any(feature = "log", feature = "secure_log")))]
         mod no_log {
@@ -402,6 +405,9 @@ mod test {
             use error_stack::ResultExt;
             use pretty_assertions::{assert_eq, assert_ne};
             use std::path::Path;
+            use crate::Error;
+            use crate::tests::enhanced::get_bytes;
+            use crate::error::FSProblem;
 
             /// Test if the overwrite method for this particular erase protocol work well or not.
             ///

--- a/src/engine/planner.rs
+++ b/src/engine/planner.rs
@@ -13,12 +13,30 @@ use error_stack::{Report, ResultExt};
 #[cfg(feature = "log")]
 use log::error;
 
+/// An ordered list of filesystem entries to process during a deletion run.
+///
+/// `files` are overwritten and removed first; `directories` are removed in
+/// reverse order afterwards so that children are always cleaned up before
+/// their parent.
 #[derive(Debug)]
 pub(crate) struct ExecutionPlan {
+    /// Regular files to overwrite and delete, in discovery order.
     pub files: Vec<PathBuf>,
+    /// Directories to remove after all files have been deleted, deepest first.
     pub directories: Vec<PathBuf>,
 }
 
+/// Walks the filesystem tree rooted at `root_path` and builds an
+/// [`ExecutionPlan`].
+///
+/// If `root_path` is a regular file, the plan contains only that file. If it
+/// is a directory, the function recurses into every subdirectory and collects
+/// all files.
+///
+/// # Errors
+///
+/// Returns an error if `root_path` does not exist or a directory entry cannot
+/// be read.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn execution_plan(root_path: &Path) -> Result<ExecutionPlan> {
     let mut files = Vec::new();
@@ -84,6 +102,17 @@ fn visit(path: &Path, files: &mut Vec<PathBuf>, directories: &mut Vec<PathBuf>) 
     Ok(())
 }
 
+/// Walks the filesystem tree rooted at `root_path` and builds an
+/// [`ExecutionPlan`].
+///
+/// If `root_path` is a regular file, the plan contains only that file. If it
+/// is a directory, the function recurses into every subdirectory and collects
+/// all files.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if
+/// `root_path` does not exist or a directory entry cannot be read.
 #[cfg(feature = "error-stack")]
 pub(crate) fn execution_plan(root_path: &Path) -> Result<ExecutionPlan> {
     let mut files = Vec::new();

--- a/src/engine/planner.rs
+++ b/src/engine/planner.rs
@@ -8,10 +8,10 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
-use error_stack::{Context, Report, ResultExt};
+use error_stack::{Report, ResultExt};
 
 #[cfg(feature = "log")]
-use log::{error, info, warn};
+use log::error;
 
 #[derive(Debug)]
 pub(crate) struct ExecutionPlan {
@@ -95,7 +95,7 @@ pub(crate) fn execution_plan(root_path: &Path) -> Result<ExecutionPlan> {
 #[cfg(feature = "error-stack")]
 fn visit(path: &Path, files: &mut Vec<PathBuf>, directories: &mut Vec<PathBuf>) -> Result<()> {
     #[cfg(feature = "secure_log")]
-    let md5_value = md5::compute(&path.to_string_lossy().to_string());
+    let md5_value = md5::compute(path.to_string_lossy().to_string());
 
     if !path.exists() {
         #[cfg(all(feature = "log", not(feature = "secure_log")))]
@@ -103,7 +103,7 @@ fn visit(path: &Path, files: &mut Vec<PathBuf>, directories: &mut Vec<PathBuf>) 
         #[cfg(all(feature = "log", feature = "secure_log"))]
         error!(
             "[{:x}]\tdid not exist",
-            md5::compute(&path.to_string_lossy().to_string())
+            md5::compute(path.to_string_lossy().to_string())
         );
         return Err(Report::new(Error::SystemProblem(
             FSProblem::NotFound,

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -19,12 +19,18 @@ use error_stack::ResultExt;
 use log::trace;
 use rand::Rng;
 
+/// Generates a cryptographically random 32-byte seed suitable for seeding a
+/// deterministic PRNG (e.g. [`rand::rngs::StdRng`]).
 pub(crate) fn generate_seed() -> [u8; 32] {
     let mut seed = [0u8; 32];
     rand::rng().fill_bytes(&mut seed);
     seed
 }
 
+/// Generates a buffer of `size` bytes filled by repeating `pattern` cyclically.
+///
+/// Used during post-overwrite verification to reconstruct the expected byte
+/// sequence for a 3-byte pattern pass. Only available with the `verify` feature.
 #[cfg(feature = "verify")]
 pub(super) fn get_three_bytes_pattern_buffer(pattern: &[u8; 3], size: usize) -> Vec<u8> {
     let mut buffer = Vec::<u8>::new();
@@ -35,6 +41,15 @@ pub(super) fn get_three_bytes_pattern_buffer(pattern: &[u8; 3], size: usize) -> 
     buffer
 }
 
+/// Securely removes a regular file by progressively renaming it to a sequence
+/// of zero-character names before calling [`std::fs::remove_file`].
+///
+/// The renaming strategy obscures the original filename in the directory entry
+/// before the file is unlinked, reducing metadata leakage.
+///
+/// # Errors
+///
+/// Returns an error if any rename or the final removal fails.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn delete_file(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]
@@ -86,12 +101,25 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
     })
 }
 
+/// Forwards `event` to `sink`, catching any panic that might occur inside the
+/// sink implementation so that a misbehaving observer can never abort the
+/// deletion pipeline.
 pub(crate) fn emit_safe<S: EventSink>(sink: &mut S, event: DeleteEvent) {
     let _ = catch_unwind(AssertUnwindSafe(|| {
         sink.emit(event);
     }));
 }
 
+/// Removes an empty directory by progressively renaming it to zero-character
+/// names before calling [`std::fs::remove_dir`].
+///
+/// Mirrors [`delete_file`] but operates on directories. The caller is
+/// responsible for ensuring that the directory is empty before calling this
+/// function.
+///
+/// # Errors
+///
+/// Returns an error if any rename or the final removal fails.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn delete_dir(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]
@@ -152,6 +180,16 @@ fn zero_name(path: &Path) -> Result<String> {
     Ok(new_name)
 }
 
+/// Securely removes a regular file by progressively renaming it to a sequence
+/// of zero-character names before calling [`std::fs::remove_file`].
+///
+/// The renaming strategy obscures the original filename in the directory entry
+/// before the file is unlinked, reducing metadata leakage.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if any
+/// rename or the final removal fails.
 #[cfg(feature = "error-stack")]
 pub(crate) fn delete_file(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]
@@ -203,6 +241,17 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
     ))
 }
 
+/// Removes an empty directory by progressively renaming it to zero-character
+/// names before calling [`std::fs::remove_dir`].
+///
+/// Mirrors [`delete_file`] but operates on directories. The caller is
+/// responsible for ensuring that the directory is empty before calling this
+/// function.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if any
+/// rename or the final removal fails.
 #[cfg(feature = "error-stack")]
 pub(crate) fn delete_dir(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -14,10 +14,10 @@ use crate::{DeleteEvent, EventSink, SecureDelete};
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
-use error_stack::{Context, Report, ResultExt};
+use error_stack::ResultExt;
 #[cfg(feature = "log")]
 use log::trace;
-use rand::RngCore;
+use rand::Rng;
 
 pub(crate) fn generate_seed() -> [u8; 32] {
     let mut seed = [0u8; 32];
@@ -155,7 +155,7 @@ fn zero_name(path: &Path) -> Result<String> {
 #[cfg(feature = "error-stack")]
 pub(crate) fn delete_file(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]
-    let md5_value = md5::compute(&path.to_string_lossy().to_string());
+    let md5_value = md5::compute(path.to_string_lossy().to_string());
     #[cfg(feature = "log")]
     trace!("[{}]\tBeginning of deletion", &path.to_string_lossy());
     #[cfg(feature = "secure_log")]
@@ -175,7 +175,7 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
     trace!(
         "[{:x}]\tRenaming to {:x}",
         &md5_value,
-        md5::compute(&new_path.to_string_lossy().to_string())
+        md5::compute(new_path.to_string_lossy().to_string())
     );
 
     let mut anon_file_size = zero_name.len();
@@ -194,7 +194,7 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
         trace!(
             "[{:x}]\tRenaming to {:x}",
             &md5_value,
-            md5::compute(&new_path.to_string_lossy().to_string())
+            md5::compute(new_path.to_string_lossy().to_string())
         );
     }
     fs::remove_file(&new_path).change_context(Error::SystemProblem(
@@ -206,7 +206,7 @@ pub(crate) fn delete_file(path: &Path) -> Result<()> {
 #[cfg(feature = "error-stack")]
 pub(crate) fn delete_dir(path: &Path) -> Result<()> {
     #[cfg(feature = "secure_log")]
-    let md5_value = md5::compute(&path.to_string_lossy().to_string());
+    let md5_value = md5::compute(path.to_string_lossy().to_string());
     #[cfg(feature = "log")]
     trace!("[{}]\tBeginning of deletion", &path.to_string_lossy());
     #[cfg(feature = "secure_log")]
@@ -226,7 +226,7 @@ pub(crate) fn delete_dir(path: &Path) -> Result<()> {
     trace!(
         "[{:x}]\tRenaming to {:x}",
         &md5_value,
-        md5::compute(&new_path.to_string_lossy().to_string())
+        md5::compute(new_path.to_string_lossy().to_string())
     );
 
     let mut anon_file_size = zero_name.len();
@@ -245,7 +245,7 @@ pub(crate) fn delete_dir(path: &Path) -> Result<()> {
         trace!(
             "[{:x}]\tRenaming to {:x}",
             &md5_value,
-            md5::compute(&new_path.to_string_lossy().to_string())
+            md5::compute(new_path.to_string_lossy().to_string())
         );
     }
     fs::remove_dir(&new_path).change_context(Error::SystemProblem(

--- a/src/engine/verify.rs
+++ b/src/engine/verify.rs
@@ -18,14 +18,34 @@ use crate::{Error, Result};
 #[cfg(feature = "error-stack")]
 use error_stack::{Report, ResultExt};
 
+/// Describes the expected byte content of the last overwrite pass so that
+/// [`verify_last_pass`] can reconstruct and compare the expected data.
 #[derive(Debug, Clone)]
 pub(crate) enum LastPassInfo {
+    /// The last pass filled the file with `0x00` bytes.
     Zero,
+    /// The last pass repeated the given 3-byte pattern cyclically.
     ThreeBytesPattern([u8; 3]),
+    /// The last pass filled the file with a single repeated byte value.
     Pattern(u8),
-    Random { seed: [u8; 32] },
+    /// The last pass filled the file with pseudo-random data seeded by `seed`.
+    Random {
+        /// The seed used to initialise the PRNG for this pass.
+        seed: [u8; 32],
+    },
 }
 
+/// Reads back the file at `path` and verifies that every byte matches the
+/// pattern described by `info`.
+///
+/// Emits [`DeleteEvent::VerificationStarted`] before reading and either
+/// [`DeleteEvent::VerificationCompleted`] on success or
+/// [`DeleteEvent::VerificationFailed`] on mismatch.
+///
+/// # Errors
+///
+/// Returns [`Error::VerificationFailed`] if a byte mismatch is detected, or an
+/// I/O error if the file cannot be opened or read.
 #[cfg(not(feature = "error-stack"))]
 pub(crate) fn verify_last_pass<S: EventSink>(
     path: &PathBuf,
@@ -118,6 +138,11 @@ pub(crate) fn verify_last_pass<S: EventSink>(
     Ok(())
 }
 
+/// Simulates a last-pass verification by emitting the expected events without
+/// reading the file.
+///
+/// Used during dry-run executions to preserve the event sequence seen by
+/// [`EventSink`] implementations without performing actual I/O.
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_verify_last_pass<S: EventSink>(
     path: &PathBuf,
@@ -322,6 +347,17 @@ mod tests {
     }
 }
 
+/// Reads back the file at `path` and verifies that every byte matches the
+/// pattern described by `info`.
+///
+/// Emits [`DeleteEvent::VerificationStarted`] before reading and either
+/// [`DeleteEvent::VerificationCompleted`] on success or
+/// [`DeleteEvent::VerificationFailed`] on mismatch.
+///
+/// # Errors
+///
+/// Returns an [`error_stack::Report`] wrapping [`Error::VerificationFailed`] if
+/// a byte mismatch is detected, or an I/O error if the file cannot be read.
 #[cfg(feature = "error-stack")]
 pub(crate) fn verify_last_pass<S: EventSink>(
     path: &PathBuf,
@@ -422,6 +458,11 @@ pub(crate) fn verify_last_pass<S: EventSink>(
     Ok(())
 }
 
+/// Simulates a last-pass verification by emitting the expected events without
+/// reading the file.
+///
+/// Used during dry-run executions to preserve the event sequence seen by
+/// [`EventSink`] implementations without performing actual I/O.
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_verify_last_pass<S: EventSink>(
     path: &Path,

--- a/src/engine/verify.rs
+++ b/src/engine/verify.rs
@@ -1,11 +1,14 @@
 use crate::DeleteEvent;
 use crate::engine::events::EventSink;
 use crate::engine::utils::{emit_safe, get_three_bytes_pattern_buffer};
+use rand::Rng;
+use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
+#[cfg(feature = "error-stack")]
+use std::path::Path;
 
 use crate::error::FSProblem;
 #[cfg(not(feature = "error-stack"))]
@@ -118,19 +121,13 @@ pub(crate) fn verify_last_pass<S: EventSink>(
 #[cfg(all(not(feature = "error-stack"), feature = "dry-run"))]
 pub(crate) fn dry_verify_last_pass<S: EventSink>(
     path: &PathBuf,
-    info: LastPassInfo,
+    _info: LastPassInfo,
     sink: &mut S,
 ) -> Result<()> {
     emit_safe(
         sink,
         DeleteEvent::VerificationStarted { path: path.clone() },
     );
-    match info {
-        LastPassInfo::Zero => Ok(()),
-        LastPassInfo::ThreeBytesPattern(pattern) => Ok(()),
-        LastPassInfo::Pattern(p) => Ok(()),
-        LastPassInfo::Random { seed } => Ok(()),
-    }
     emit_safe(
         sink,
         DeleteEvent::VerificationCompleted { path: path.clone() },
@@ -236,6 +233,8 @@ mod tests {
     use super::*;
     use crate::Error;
     use pretty_assertions::assert_eq;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use std::fs::{File, OpenOptions};
     use std::io::{Seek, SeekFrom, Write};
     use std::path::PathBuf;
@@ -260,9 +259,6 @@ mod tests {
 
     #[test]
     fn verify_random_detects_corruption() {
-        use rand::rngs::StdRng;
-        use rand::{RngCore, SeedableRng};
-
         let path = PathBuf::from("test_random_fail.tmp");
 
         let seed = [42u8; 32];
@@ -303,9 +299,6 @@ mod tests {
 
     #[test]
     fn verify_random_ok() {
-        use rand::rngs::StdRng;
-        use rand::{RngCore, SeedableRng};
-
         let path = PathBuf::from("test_random_ok.tmp");
         let seed = [7u8; 32];
 
@@ -357,7 +350,7 @@ pub(crate) fn verify_last_pass<S: EventSink>(
     let mut buffer = vec![0u8; 8192];
 
     match info {
-        LastPassInfo::Zero => match verify_fixed(&mut file, 0x00, &mut buffer, &path) {
+        LastPassInfo::Zero => match verify_fixed(&mut file, 0x00, &mut buffer, path) {
             Ok(_) => {}
             Err(report) => {
                 if let Error::VerificationFailed { offset } = report.current_context() {
@@ -373,7 +366,7 @@ pub(crate) fn verify_last_pass<S: EventSink>(
             }
         },
         LastPassInfo::ThreeBytesPattern(pattern) => {
-            match verify_three_bytes_pattern(&mut file, &pattern, &mut buffer, &path) {
+            match verify_three_bytes_pattern(&mut file, &pattern, &mut buffer, path) {
                 Ok(_) => {}
                 Err(report) => {
                     if let Error::VerificationFailed { offset } = report.current_context() {
@@ -389,7 +382,7 @@ pub(crate) fn verify_last_pass<S: EventSink>(
                 }
             }
         }
-        LastPassInfo::Pattern(p) => match verify_fixed(&mut file, p, &mut buffer, &path) {
+        LastPassInfo::Pattern(p) => match verify_fixed(&mut file, p, &mut buffer, path) {
             Ok(_) => {}
             Err(report) => {
                 if let Error::VerificationFailed { offset } = report.current_context() {
@@ -404,7 +397,7 @@ pub(crate) fn verify_last_pass<S: EventSink>(
                 return Err(report);
             }
         },
-        LastPassInfo::Random { seed } => match verify_random(&mut file, seed, &mut buffer, &path) {
+        LastPassInfo::Random { seed } => match verify_random(&mut file, seed, &mut buffer, path) {
             Ok(_) => {}
             Err(report) => {
                 if let Error::VerificationFailed { offset } = report.current_context() {
@@ -431,23 +424,17 @@ pub(crate) fn verify_last_pass<S: EventSink>(
 
 #[cfg(all(feature = "error-stack", feature = "dry-run"))]
 pub(crate) fn dry_verify_last_pass<S: EventSink>(
-    path: &PathBuf,
-    info: LastPassInfo,
+    path: &Path,
+    _info: LastPassInfo,
     sink: &mut S,
 ) -> Result<()> {
     emit_safe(
         sink,
-        DeleteEvent::VerificationStarted { path: path.clone() },
+        DeleteEvent::VerificationStarted { path: path.to_path_buf() },
     );
-    match info {
-        LastPassInfo::Zero => Ok(()),
-        LastPassInfo::ThreeBytesPattern(pattern) => Ok(()),
-        LastPassInfo::Pattern(p) => Ok(()),
-        LastPassInfo::Random { seed } => Ok(()),
-    }
     emit_safe(
         sink,
-        DeleteEvent::VerificationCompleted { path: path.clone() },
+        DeleteEvent::VerificationCompleted { path: path.to_path_buf() },
     );
     Ok(())
 }
@@ -456,7 +443,7 @@ fn verify_fixed(
     file: &mut std::fs::File,
     expected: u8,
     buffer: &mut [u8],
-    path: &PathBuf,
+    path: &Path,
 ) -> Result<()> {
     let mut offset: u64 = 0;
 
@@ -488,7 +475,7 @@ fn verify_random(
     file: &mut std::fs::File,
     seed: [u8; 32],
     buffer: &mut [u8],
-    path: &PathBuf,
+    path: &Path,
 ) -> Result<()> {
     let mut rng = StdRng::from_seed(seed);
     let mut offset: u64 = 0;
@@ -524,7 +511,7 @@ fn verify_three_bytes_pattern(
     file: &mut File,
     pattern: &[u8; 3],
     buffer: &mut [u8],
-    path: &PathBuf,
+    path: &Path,
 ) -> Result<()> {
     use std::io::Read;
 
@@ -538,7 +525,7 @@ fn verify_three_bytes_pattern(
             break;
         }
 
-        let expected = get_three_bytes_pattern_buffer(&pattern, bytes_read);
+        let expected = get_three_bytes_pattern_buffer(pattern, bytes_read);
 
         for i in 0..bytes_read {
             if buffer[i] != expected[i] {
@@ -558,6 +545,8 @@ fn verify_three_bytes_pattern(
 mod tests {
     use super::*;
     use crate::Error;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use std::fs::{File, OpenOptions};
     use std::io::{Seek, SeekFrom, Write};
     use std::path::PathBuf;
@@ -582,9 +571,6 @@ mod tests {
 
     #[test]
     fn verify_random_detects_corruption() {
-        use rand::rngs::StdRng;
-        use rand::{RngCore, SeedableRng};
-
         let path = PathBuf::from("test_random_fail.tmp");
 
         let seed = [42u8; 32];
@@ -628,9 +614,6 @@ mod tests {
 
     #[test]
     fn verify_random_ok() {
-        use rand::rngs::StdRng;
-        use rand::{RngCore, SeedableRng};
-
         let path = PathBuf::from("test_random_ok.tmp");
         let seed = [7u8; 32];
 

--- a/src/error/enhanced.rs
+++ b/src/error/enhanced.rs
@@ -1,37 +1,55 @@
+//! `error-stack`-based error types (deprecated variant).
+//!
+//! This module is only compiled when the `error-stack` feature is enabled.
+//! It mirrors [`super::standard`] but wraps errors in
+//! [`error_stack::Report`] for richer context chains.
+//!
+//! **Deprecated since `3.1.0`.** Use the default error system instead.
+//! This module will be removed in `4.0.0`.
+
 use crate::error::FSProblem;
 use crate::{Method, models::SecureDelete};
-use error_stack::Context;
-
-/// Reexporting Result type
+/// A `Result` alias backed by [`error_stack::Report`] for richer error context.
+///
+/// **Deprecated since `3.1.0`.**
 #[deprecated(
     since = "3.1.0",
     note = "This legacy error system will be removed in `4.0.0`. Please use the default Error system instead."
 )]
-pub type Result<T> = error_stack::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, error_stack::Report<Error>>;
 
-/// Enum used to represent errors in the library
+/// Errors that can be produced by the Nozomi library (`error-stack` variant).
+///
+/// **Deprecated since `3.1.0`.** Use the default [`Error`](crate::error::standard::Error) instead.
 #[derive(Debug, Clone)]
 #[deprecated(
     since = "3.1.0",
     note = "This legacy error system will be removed in `4.0.0`. Please use the default Error system instead."
 )]
 pub enum Error {
-    /// Represent file problems with FSProblem and String
+    /// A filesystem operation failed. Contains the operation category and the
+    /// path that was being processed.
     SystemProblem(FSProblem, String),
-    /// Represent an error during a specific overwrite method with Method and step
+    /// An overwrite pass failed for the given [`Method`](crate::Method) at the
+    /// indicated pass number.
     OverwriteError(Method, u32),
-    /// Represent the fact that we cannot found a file/folder name for a given path
+    /// The provided path has no filename component.
     NoFileName(SecureDelete),
-    /// Error during path to string conversion
+    /// A [`Path`](std::path::Path) could not be converted to a valid UTF-8 string.
     StringConversionError,
-    /// error to help during debug phase
-    #[cfg(test)]
-    FileCreationError,
+    /// A required builder parameter was not set. The contained string names the
+    /// missing field.
     MissingParameter(&'static str),
+    /// A post-overwrite verification read back unexpected bytes at the given
+    /// byte offset. Only available with the `verify` feature.
     #[cfg(feature = "verify")]
     VerificationFailed {
+        /// Byte offset of the first mismatched byte within the file.
         offset: u64,
     },
+    /// Produced when creating temporary test files fails.
+    #[cfg(test)]
+    FileCreationError,
 }
 
 /// Implementing display trait for Error enum

--- a/src/error/enhanced.rs
+++ b/src/error/enhanced.rs
@@ -84,4 +84,4 @@ impl core::fmt::Display for Error {
     }
 }
 
-impl Context for Error {}
+impl std::error::Error for Error {}

--- a/src/error/enhanced.rs
+++ b/src/error/enhanced.rs
@@ -3,10 +3,18 @@ use crate::{Method, models::SecureDelete};
 use error_stack::Context;
 
 /// Reexporting Result type
+#[deprecated(
+    since = "3.1.0",
+    note = "This legacy error system will be removed in `4.0.0`. Please use the default Error system instead."
+)]
 pub type Result<T> = error_stack::Result<T, Error>;
 
 /// Enum used to represent errors in the library
 #[derive(Debug, Clone)]
+#[deprecated(
+    since = "3.1.0",
+    note = "This legacy error system will be removed in `4.0.0`. Please use the default Error system instead."
+)]
 pub enum Error {
     /// Represent file problems with FSProblem and String
     SystemProblem(FSProblem, String),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,3 +1,14 @@
+//! Error types used throughout the library.
+//!
+//! Two implementations are provided depending on the active feature flag:
+//!
+//! - **default** (`standard`) — uses the standard [`core::error::Error`] trait.
+//! - **`error-stack`** (`enhanced`) — wraps errors in an [`error_stack::Report`]
+//!   for richer context. This variant is deprecated and will be removed in `4.0.0`.
+//!
+//! [`FSProblem`] is shared between both variants and describes the category of
+//! filesystem operation that failed.
+
 #[cfg(not(feature = "error-stack"))]
 pub mod standard;
 
@@ -5,25 +16,30 @@ pub mod standard;
 #[allow(deprecated)]
 pub mod enhanced;
 
-/// Enum that represent different kind of file system problem that Nozomi lib can encounter
+/// Identifies the category of filesystem operation that produced an error.
+///
+/// Carried inside [`Error::SystemProblem`](crate::Error::SystemProblem) to give
+/// callers and logging tooling precise context about what the engine was
+/// attempting when the failure occurred.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum FSProblem {
-    /// Problem during rename process
+    /// Failure while renaming a file or directory.
     Rename,
-    /// Problem during file opening operation
+    /// Failure while opening a file for reading or writing.
     Opening,
-    /// Problem during writing process
+    /// Failure while writing data to a file.
     Write,
+    /// Failure while reading data from a file (requires the `verify` feature).
     #[cfg(feature = "verify")]
     Read,
-    /// Problem during deletion process
+    /// Failure while removing a file or directory from the filesystem.
     Delete,
-    /// Problem during file enumeration process
+    /// Failure while enumerating the entries of a directory.
     ReadFolder,
-    /// Can not found a file or a folder
+    /// The requested file or directory does not exist.
     NotFound,
-    /// Problem with file/folder process
+    /// Failure while querying or modifying filesystem permissions.
     Permissions,
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -2,6 +2,7 @@
 pub mod standard;
 
 #[cfg(feature = "error-stack")]
+#[allow(deprecated)]
 pub mod enhanced;
 
 /// Enum that represent different kind of file system problem that Nozomi lib can encounter

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -44,4 +44,5 @@ impl core::fmt::Display for FSProblem {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "error-stack"))]
 pub(crate) fn rfc1236<T: core::error::Error + Send + Sync + 'static>() {}

--- a/src/error/standard.rs
+++ b/src/error/standard.rs
@@ -1,29 +1,37 @@
+//! Standard error types (default, non-`error-stack` variant).
+
 use crate::error::FSProblem;
 use crate::{Method, models::SecureDelete};
 
-#[cfg(not(feature = "error-stack"))]
-/// Reexporting Result type
+/// A `Result` alias that fixes the error type to [`Error`].
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Enum used to represent errors in the library
+/// Errors that can be produced by the Nozomi library.
 #[derive(Debug)]
 pub enum Error {
-    /// Represent file problems with FSProblem and String
+    /// A filesystem operation failed. Contains the operation category and the
+    /// path that was being processed.
     SystemProblem(FSProblem, String),
-    /// Represent an error during a specific overwrite method with Method and step
+    /// An overwrite pass failed for the given [`Method`] at the indicated pass number.
     OverwriteError(Method, u32),
-    /// Represent the fact that we cannot found a file/folder name for a given path
+    /// The provided path has no filename component (e.g. it is a bare root or
+    /// ends in `..`).
     NoFileName(SecureDelete),
-    /// Error during path to string conversion
+    /// A [`Path`](std::path::Path) could not be converted to a valid UTF-8 string.
     StringConversionError,
-    /// Wrapper for std::io:Error to help during debug phase
-    #[cfg(test)]
-    FileCreationError(std::io::Error),
+    /// A required builder parameter was not set. The contained string names the
+    /// missing field.
     MissingParameter(&'static str),
+    /// A post-overwrite verification read back unexpected bytes at the given
+    /// byte offset. Only available with the `verify` feature.
     #[cfg(feature = "verify")]
     VerificationFailed {
+        /// Byte offset of the first mismatched byte within the file.
         offset: u64,
     },
+    /// Wraps a [`std::io::Error`] produced when creating temporary test files.
+    #[cfg(test)]
+    FileCreationError(std::io::Error),
 }
 
 /// Implementing display trait for Error enum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,20 @@
 // -- Libraries use in this library
 #[cfg(feature = "analyze")]
 mod analyze;
+#[allow(deprecated)]
 mod error;
 mod methods;
+#[allow(deprecated)]
 mod models;
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests;
 #[cfg(feature = "analyze")]
 pub use analyze::{AnalysisReport, PassInfo, PassKind};
 
+#[allow(deprecated)]
 pub mod api;
+#[allow(deprecated)]
 mod engine;
 
 pub use api::delete::DeleteMethod;
@@ -21,10 +26,12 @@ pub use engine::events::{DeleteEvent, EventSink};
 
 // -- Export object
 pub use crate::methods::Method;
+#[allow(deprecated)]
 pub use crate::models::SecureDelete;
 
 // -- Export Error and Result type
 #[cfg(feature = "error-stack")]
+#[allow(deprecated)]
 pub use crate::error::enhanced::{Error, Result};
 #[cfg(not(feature = "error-stack"))]
 pub use crate::error::standard::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,47 @@
+//! # Nozomi
+//!
+//! Nozomi is a Rust library for **secure file deletion**. It implements several
+//! industry-standard overwrite methods that prevent data recovery by overwriting
+//! file contents with specific byte patterns before removing the file from the
+//! filesystem.
+//!
+//! ## Supported sanitisation standards
+//!
+//! | Variant | Standard | Passes |
+//! |---------|----------|--------|
+//! | [`Method::PseudoRandom`] | Random data | 1 |
+//! | [`Method::HmgiS5`] | HMGI S5 | 2 |
+//! | [`Method::Afssi5020`] | AFSSI 5020 | 3 |
+//! | [`Method::Dod522022ME`] | DoD 5220.22-M (ME) | 3 |
+//! | [`Method::RcmpTssitOpsII`] | RCMP TSSIT OPS-II | 7 |
+//! | [`Method::Dod522022MECE`] | DoD 5220.22-M (ECE) | 7 |
+//! | [`Method::Gutmann`] | Gutmann | 35 |
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use nozomi::{DeleteRequest, DeleteMethod, Method};
+//!
+//! let report = DeleteRequest::builder()
+//!     .path("/path/to/sensitive/file.txt")
+//!     .method(DeleteMethod::BuiltIn(Method::Gutmann))
+//!     .build()?
+//!     .run()?;
+//!
+//! println!("Deleted {:?} using {}", report.path, report.method);
+//! # Ok::<(), nozomi::Error>(())
+//! ```
+//!
+//! ## Optional features
+//!
+//! | Feature | Description |
+//! |---------|-------------|
+//! | `dry-run` | Simulate deletions without writing to disk |
+//! | `verify` | Read back the last overwrite pass to confirm correctness |
+//! | `analyze` | Inspect the pass schedule of a [`Method`] before running it |
+//! | `error-stack` | Use [`error_stack`](https://docs.rs/error-stack) for richer error context (deprecated, will be removed in `4.0.0`) |
+//! | `log` | Emit trace-level log entries via the `log` facade |
+
 // -- Libraries use in this library
 #[cfg(feature = "analyze")]
 mod analyze;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 mod analyze;
 #[allow(deprecated)]
 mod error;
+#[allow(deprecated)]
 mod methods;
 #[allow(deprecated)]
 mod models;

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -17,22 +17,30 @@ use crate::{PassInfo, PassKind};
 use crate::engine::run;
 // -- Region : Method logic
 
-/// Nozomi Eraser method enumeration based on Eraser for Windows main method
+/// Identifies the overwrite algorithm to use when securely deleting a file.
+///
+/// Each variant maps to an industry-standard data sanitisation method. The
+/// variants are ordered roughly by the number of overwrite passes they perform,
+/// from fastest to most thorough.
+///
+/// `PseudoRandom` is the default and is suitable for most use cases. Use
+/// `Gutmann` only when you require the maximum theoretical guarantee for
+/// magnetic media.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum Method {
-    /// DOD 522022 MECE erasing method <https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php>
+    /// [DoD 5220.22-M (ECE)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php) — 7 passes.
     Dod522022MECE,
-    /// DOD 522022 ME erasing method <https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php>
+    /// [DoD 5220.22-M (ME)](https://www.bitraser.com/article/DoD-5220-22-m-standard-for-drive-erasure.php) — 3 passes.
     Dod522022ME,
-    /// AFSSI 5020 erasing method <https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020>
+    /// [AFSSI 5020](https://www.lifewire.com/data-sanitization-methods-2626133#toc-afssi-5020) — 3 passes.
     Afssi5020,
-    /// RCMP TSSIT OPS II erasing method <https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html>
+    /// [RCMP TSSIT OPS-II](https://www.datadestroyers.eu/technology/rcmp_tssit_ops-2.html) — 7 passes.
     RcmpTssitOpsII,
-    /// HMGI S5 erasing method <https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php>
+    /// [HMGI S5](https://www.bitraser.com/knowledge-series/data-destruction-standards-and-guidelines.php) — 2 passes.
     HmgiS5,
-    /// Gutmann erasing method <https://en.wikipedia.org/wiki/Gutmann_method>
+    /// [Gutmann](https://en.wikipedia.org/wiki/Gutmann_method) — 35 passes.
     Gutmann,
-    /// Pseudo Random erasing method <https://www.lifewire.com/data-sanitization-methods-2626133#toc-random-data>
+    /// Single-pass pseudo-random overwrite. Fast and suitable for modern storage. Default method.
     #[default]
     PseudoRandom,
 }
@@ -40,11 +48,17 @@ pub enum Method {
 // -- Region : Implement logic for basic error handling.
 #[cfg(not(feature = "error-stack"))]
 impl Method {
-    /// This function is used to delete a file or folder using a predefined method using basic error handling method.
+    /// Securely overwrites and deletes the file or directory at `path` using
+    /// this method's algorithm.
     ///
-    /// ## Argument :
-    /// * `self` (&Method) : Nozomi Eraser method enumeration based on Eraser for Windows main method
-    /// * `path` (&str) : path that you want to erase using the given overwrite method
+    /// This is the high-level convenience entry point for the deprecated
+    /// single-argument API. Prefer [`DeleteRequest::builder`](crate::DeleteRequest::builder)
+    /// for new code as it provides event observation and dry-run support.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`](crate::Error) if the path does not exist, cannot be
+    /// overwritten, or cannot be removed.
     pub fn delete(&self, path: &str) -> Result<()> {
         let path_to_delete = Path::new(path);
         let mut sink = NoopSink;
@@ -56,11 +70,17 @@ impl Method {
 #[cfg(feature = "error-stack")]
 #[allow(deprecated)]
 impl Method {
-    /// This function is used to delete a file or folder using a predefined method using error-stack's error handling method.
+    /// Securely overwrites and deletes the file or directory at `path` using
+    /// this method's algorithm.
     ///
-    /// ## Argument :
-    /// * `self` (&Method) : Nozomi Eraser method enumeration based on Eraser for Windows main method
-    /// * `path` (&str) : path that you want to erase using the given overwrite method
+    /// This is the high-level convenience entry point for the deprecated
+    /// single-argument API. Prefer [`DeleteRequest::builder`](crate::DeleteRequest::builder)
+    /// for new code as it provides event observation and dry-run support.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`error_stack::Report`] wrapping [`Error`](crate::Error) if
+    /// the path does not exist, cannot be overwritten, or cannot be removed.
     pub fn delete(&self, path: &str) -> Result<()> {
         let path_to_delete = Path::new(path);
         let mut sink = NoopSink;
@@ -85,6 +105,14 @@ impl core::fmt::Display for Method {
 
 #[cfg(feature = "analyze")]
 impl Method {
+    /// Returns a static description of the overwrite schedule applied by this
+    /// method, without executing any I/O.
+    ///
+    /// The resulting [`AnalysisReport`] lists every pass in order with its
+    /// [`PassKind`](crate::PassKind), and can be used to display or audit the
+    /// plan before running a deletion.
+    ///
+    /// Only available when the `analyze` feature is enabled.
     pub fn analyze(&self) -> AnalysisReport {
         match &self {
             Method::Dod522022MECE => AnalysisReport {

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -5,17 +5,14 @@ use std::path::Path;
 #[cfg(not(feature = "error-stack"))]
 use crate::Result;
 use crate::api::delete::request::NoopSink;
-#[cfg(feature = "log")]
-use log::{error, info, warn};
 
 #[cfg(feature = "analyze")]
 use crate::AnalysisReport;
 #[cfg(feature = "error-stack")]
 use crate::{Error, Result};
+use crate::Result;
 #[cfg(feature = "analyze")]
 use crate::{PassInfo, PassKind};
-#[cfg(feature = "error-stack")]
-use error_stack::{Context, Report, ResultExt};
 
 use crate::engine::run;
 // -- Region : Method logic
@@ -88,7 +85,7 @@ impl core::fmt::Display for Method {
 #[cfg(feature = "analyze")]
 impl Method {
     pub fn analyze(&self) -> AnalysisReport {
-        let analysis_report = match &self {
+        match &self {
             Method::Dod522022MECE => AnalysisReport {
                 pass_count: 6,
                 passes: vec![
@@ -276,8 +273,7 @@ impl Method {
                     kind: PassKind::Random,
                 }],
             },
-        };
-        analysis_report
+        }
     }
 }
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -9,7 +9,7 @@ use crate::api::delete::request::NoopSink;
 #[cfg(feature = "analyze")]
 use crate::AnalysisReport;
 #[cfg(feature = "error-stack")]
-use crate::{Error, Result};
+#[allow(deprecated)]
 use crate::Result;
 #[cfg(feature = "analyze")]
 use crate::{PassInfo, PassKind};
@@ -54,6 +54,7 @@ impl Method {
 
 // -- Region : Implement logic for error-stack's error handling.
 #[cfg(feature = "error-stack")]
+#[allow(deprecated)]
 impl Method {
     /// This function is used to delete a file or folder using a predefined method using error-stack's error handling method.
     ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -332,6 +332,10 @@ impl SecureDelete {
 
     #[cfg(feature = "verify")]
     pub fn verify(&self) -> Result<bool> {
+        #[cfg(feature = "dry-run")]
+        if self.dry_run {
+            return Ok(true);
+        }
         let mut sink = NoopSink {};
         if let Some(byte) = self.byte {
             let result = verify_last_pass(
@@ -587,7 +591,7 @@ impl SecureDelete {
         #[cfg(feature = "log")]
         trace!("[{}]\tSecure deletion object creation", &path);
         #[cfg(feature = "secure_log")]
-        let computed_md5 = md5::compute(&path);
+        let computed_md5 = md5::compute(path);
         #[cfg(feature = "secure_log")]
         trace!("[{:x}]\tSecure deletion object creation", &computed_md5);
 
@@ -739,7 +743,7 @@ impl SecureDelete {
     pub fn verify(&self) -> Result<bool> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
-            return Ok(self);
+            return Ok(true);
         }
         let mut sink = NoopSink {};
         if let Some(byte) = self.byte {

--- a/src/models.rs
+++ b/src/models.rs
@@ -26,6 +26,10 @@ use std::{
 /// Secure Delete object : backbone of
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
+#[deprecated(
+    since = "3.1.0",
+    note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+)]
 pub struct SecureDelete {
     /// File/Folder path that you want to overwrite/delete
     pub(crate) path: String,
@@ -54,6 +58,10 @@ impl SecureDelete {
     ///
     /// ## Return
     /// * `&mut self` (SecureDelete) : The object itself that can be used to call an other function as buffer (by example)
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn byte(&mut self, byte: &u8) -> &mut Self {
         #[cfg(feature = "log")]
         trace!("[{}]\tbyte [{:x}]\tpattern [None]", &self.path, byte);
@@ -73,6 +81,10 @@ impl SecureDelete {
     ///
     /// ## Return
     /// * `&mut self` (SecureDelete) : The object itself that can be used to call an other function as buffer (by example)
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn pattern(&mut self, pattern: &[u8; 3]) -> &mut Self {
         #[cfg(feature = "log")]
         trace!(
@@ -97,6 +109,10 @@ impl SecureDelete {
     ///
     /// ## Return
     /// * `&mut self` (SecureDelete) : The object itself that can be used to call an other function as byte (by example)
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn buffer(&mut self, new_buffer_size: usize) -> &mut Self {
         #[cfg(feature = "log")]
         trace!("[{}]\tbuffer size [{}]", &self.path, new_buffer_size);
@@ -139,21 +155,29 @@ impl SecureDelete {
     }
 
     #[cfg(feature = "dry-run")]
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn dry_run(&mut self) -> &mut Self {
         self.dry_run = true;
         self
     }
 
     #[cfg(feature = "analyze")]
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn get_pass_info(&self) -> PassInfo {
         if let Some(byte) = &self.byte {
             return PassInfo {
-                kind: PassKind::Pattern(byte.clone()),
+                kind: PassKind::Pattern(*byte),
             };
         }
         if let Some(bytes_pattern) = self.pattern {
             return PassInfo {
-                kind: PassKind::ThreeBytePattern(bytes_pattern.clone()),
+                kind: PassKind::ThreeBytePattern(bytes_pattern),
             };
         }
         PassInfo {
@@ -169,6 +193,10 @@ impl SecureDelete {
     ///
     /// ## Arguments
     /// * `path` (&str) : path that you want to overwrite/delete
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn new(path: &str) -> Result<Self> {
         if !Path::new(&path).exists() {
             return Err(Error::SystemProblem(FSProblem::NotFound, path.to_string()));
@@ -198,6 +226,10 @@ impl SecureDelete {
     ///
     /// ## Arguments
     /// * `&mut self` (SecureDelete) : The object itself that can be modified
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn delete(&mut self) -> Result<()> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -241,6 +273,10 @@ impl SecureDelete {
     /// ## Arguments
     /// * `&mut self` (SecureDelete) : The object itself that can be modified
     /// * `new_name` (&Path) : New file name as Path struct
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn rename(&mut self, new_name: &Path) -> Result<()> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -271,6 +307,10 @@ impl SecureDelete {
     ///
     /// ## Return
     /// * `&mut self` (SecureDelete) : The object itself that can be used to call an other function as delete (by example)
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn overwrite(&mut self) -> Result<&mut Self> {
         #[cfg(feature = "log")]
         trace!("[{}]\tBegging of overwriting phase", &self.path);
@@ -580,6 +620,10 @@ impl SecureDelete {
     ///
     /// ## Arguments
     /// * `path` (&str) : path that you want to overwrite/delete
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn new(path: &str) -> Result<Self> {
         if !Path::new(&path).exists() {
             return Err(Report::new(Error::SystemProblem(
@@ -613,6 +657,10 @@ impl SecureDelete {
     ///
     /// ## Arguments
     /// * `&mut self` (SecureDelete) : The object itself that can be modified
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn delete(&mut self) -> Result<()> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -656,6 +704,10 @@ impl SecureDelete {
     /// ## Arguments
     /// * `&mut self` (SecureDelete) : The object itself that can be modified
     /// * `new_name` (&Path) : New file name as Path struct
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn rename(&mut self, new_name: &Path) -> Result<()> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {
@@ -685,6 +737,10 @@ impl SecureDelete {
     ///
     /// ## Return
     /// * `&mut self` (SecureDelete) : The object itself that can be used to call an other function as delete (by example)
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn overwrite(&mut self) -> Result<&mut Self> {
         #[cfg(feature = "log")]
         trace!("[{}]\tBegging of overwriting phase", &self.path);
@@ -740,6 +796,10 @@ impl SecureDelete {
     }
 
     #[cfg(feature = "verify")]
+    #[deprecated(
+        since = "3.1.0",
+        note = "Use `DeleteRequestBuilder::build().run()` instead. This API will be removed in `4.0.0`."
+    )]
     pub fn verify(&self) -> Result<bool> {
         #[cfg(feature = "dry-run")]
         if self.dry_run {

--- a/src/tests/enhanced.rs
+++ b/src/tests/enhanced.rs
@@ -1,8 +1,10 @@
+#[cfg(not(feature = "log"))]
 use super::LOREM_IPSUM;
 use super::TestType;
+#[cfg(not(feature = "log"))]
 use crate::error::FSProblem;
 use crate::{Error, Result};
-use error_stack::{Context, ResultExt};
+use error_stack::ResultExt;
 use std::fs::create_dir_all;
 use std::io::prelude::*;
 use std::{fs::File, io::Write, path::Path};
@@ -55,6 +57,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
         .to_str()
         .ok_or(Error::StringConversionError)?;
     match test_type {
+        #[cfg(not(feature = "log"))]
         TestType::SmallFile => {
             let file_name = format!("{test_folder}/{method_name}_small_file_test");
             let lorem = "Hello, world!".to_string();
@@ -63,6 +66,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
                 .change_context(Error::FileCreationError)?;
             return Ok((file_name, lorem));
         }
+        #[cfg(not(feature = "log"))]
         TestType::MediumFile => {
             let file_name = format!("{test_folder}/{method_name}_medium_file_test");
             let mut file = File::create(&file_name).change_context(Error::FileCreationError)?;
@@ -72,6 +76,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             }
             return Ok((file_name, LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::WritingError => {
             let permission_error_file = format!("{test_folder}/permission_error.txt");
             let mut file =
@@ -88,6 +93,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             })?;
             return Ok((permission_error_file, LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::Folder => {
             let folder_to_delete = format!("{test_folder}/folder_to_delete/");
             if !Path::new(&folder_to_delete).exists() {
@@ -99,6 +105,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             }
             return Ok((folder_to_delete.to_string(), LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::OverwriteOnly => {
             let file_name = format!("{test_folder}/{method_name}_basic_over_write");
             let lorem = "Hello, world!".to_string();
@@ -107,6 +114,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
                 .change_context(Error::FileCreationError)?;
             return Ok((file_name, lorem));
         }
+        #[cfg(not(feature = "log"))]
         TestType::LargeFile => {
             let file_name = format!("{test_folder}/{method_name}_large_file_test");
             let mut file = File::create(&file_name).change_context(Error::FileCreationError)?;
@@ -116,7 +124,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             }
             return Ok((file_name, LOREM_IPSUM.to_string()));
         }
-        #[cfg(feature = "log")]
+        #[cfg(all(feature = "log",not(feature = "secure_log")))]
         TestType::LogMini => {
             let file_name = format!("{test_folder}/{method_name}_log_mini.txt");
             let lorem = "Hello, world!".to_string();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -40,24 +40,31 @@ fn validate_structure() {
 }
 
 /// Basic lorem ipsum text used to create file
+#[cfg(not(feature = "log"))]
 const LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent congue diam risus, quis hendrerit nunc commodo id. Duis volutpat vitae leo at malesuada. Phasellus libero nisl, auctor sit amet dapibus eget, egestas eget velit. Curabitur fermentum, libero vel dictum hendrerit, metus leo pellentesque tortor, et vehicula nisl felis elementum purus. Etiam eu ex in odio tincidunt maximus. Ut luctus blandit ligula et dignissim. Duis id imperdiet urna. Sed porttitor nulla vitae sollicitudin sagittis. Donec ut justo ut risus pretium dignissim. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec eu rhoncus erat, sed sagittis elit. Proin dui nisl, varius nec volutpat sed, lobortis nec tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.\n";
 
 /// Enum that describe all tests' type used to test global method
 #[derive(Debug, Clone, Copy)]
 pub enum TestType {
     /// Test deleting a 1KB file
+    #[cfg(not(feature = "log"))]
     SmallFile,
     /// Test deleting a 1MB file
+    #[cfg(not(feature = "log"))]
     MediumFile,
     /// Test deleting a 10MB file
+    #[cfg(not(feature = "log"))]
     LargeFile,
     /// Test deleting a read only file
+    #[cfg(not(feature = "log"))]
     WritingError,
     /// Test deleting a folder containing multiple files
+    #[cfg(not(feature = "log"))]
     Folder,
     /// Test the overwriting function
+    #[cfg(not(feature = "log"))]
     OverwriteOnly,
-    #[cfg(feature = "log")]
+    #[cfg(all(feature = "log",not(feature = "secure_log")))]
     /// Test deleting a 1KB file with log feature activated
     LogMini,
     #[cfg(feature = "secure_log")]

--- a/src/tests/standard.rs
+++ b/src/tests/standard.rs
@@ -1,5 +1,8 @@
+
+#[cfg(not(feature = "log"))]
 use super::LOREM_IPSUM;
 use super::TestType;
+#[cfg(not(feature = "log"))]
 use crate::error::FSProblem;
 use crate::{Error, Result};
 use std::fs::create_dir_all;
@@ -38,6 +41,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
         .to_str()
         .ok_or(Error::StringConversionError)?;
     match test_type {
+        #[cfg(not(feature = "log"))]
         TestType::SmallFile => {
             let file_name = format!("{test_folder}/{method_name}_small_file_test");
             let lorem = "Hello, world!".to_string();
@@ -46,6 +50,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
                 .map_err(|e| Error::FileCreationError(e))?;
             return Ok((file_name, lorem));
         }
+        #[cfg(not(feature = "log"))]
         TestType::MediumFile => {
             let file_name = format!("{test_folder}/{method_name}_medium_file_test");
             let mut file = File::create(&file_name).map_err(|e| Error::FileCreationError(e))?;
@@ -55,6 +60,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             }
             return Ok((file_name, LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::WritingError => {
             let permission_error_file = format!("{test_folder}/permission_error.txt");
             let mut file =
@@ -71,6 +77,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             })?;
             return Ok((permission_error_file, LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::Folder => {
             let folder_to_delete = format!("{test_folder}/folder_to_delete/");
             if !Path::new(&folder_to_delete).exists() {
@@ -91,6 +98,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
 
             return Ok((folder_to_delete.to_string(), LOREM_IPSUM.to_string()));
         }
+        #[cfg(not(feature = "log"))]
         TestType::OverwriteOnly => {
             let file_name = format!("{test_folder}/{method_name}_basic_over_write");
             let lorem = "Hello, world!".to_string();
@@ -99,6 +107,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
                 .map_err(|e| Error::FileCreationError(e))?;
             return Ok((file_name, lorem));
         }
+        #[cfg(not(feature = "log"))]
         TestType::LargeFile => {
             let file_name = format!("{test_folder}/{method_name}_large_file_test");
             let mut file = File::create(&file_name).map_err(|e| Error::FileCreationError(e))?;
@@ -108,7 +117,7 @@ pub fn create_test_file(test_type: &TestType, method_name: &str) -> Result<(Stri
             }
             return Ok((file_name, LOREM_IPSUM.to_string()));
         }
-        #[cfg(feature = "log")]
+        #[cfg(all(feature = "log",not(feature = "secure_log")))]
         TestType::LogMini => {
             let file_name = format!("{test_folder}/{method_name}_log_mini.txt");
             let lorem = "Hello, world!".to_string();

--- a/tests/dry_run_integration.rs
+++ b/tests/dry_run_integration.rs
@@ -180,6 +180,7 @@ mod test_dry_run {
 }
 
 #[cfg(all(feature = "dry-run", feature = "error-stack"))]
+#[allow(deprecated)]
 mod test_dry_run {
     use super::TestSink;
     use nozomi::{DeleteEvent, DeleteMethod, DeleteRequest, Method, Result};

--- a/tests/events/mod.rs
+++ b/tests/events/mod.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
+#[allow(deprecated)]
 mod emission_order;
+#[allow(deprecated)]
 mod error_behavior;
+#[allow(deprecated)]
 mod sink_isolation;
 
 use nozomi::{DeleteEvent, EventSink};

--- a/tests/features_compile.rs
+++ b/tests/features_compile.rs
@@ -4,7 +4,6 @@
 /// Always compiled: ensures base crate compiles without features.
 #[test]
 fn base_build_compiles() {
-    // If this test runs, the default feature set compiled successfully.
     assert!(true);
 }
 
@@ -14,12 +13,9 @@ fn base_build_compiles() {
 
 #[cfg(feature = "verify")]
 mod verify_enabled {
-    use super::*;
 
     #[test]
     fn verify_feature_compiles() {
-        // Placeholder until builder method is implemented.
-        // Ensures the crate compiles with `--features verify`.
         assert!(true);
     }
 }
@@ -54,7 +50,6 @@ mod analyze_enabled {
 
 #[cfg(feature = "error-stack")]
 mod error_stack_enabled {
-    use super::*;
 
     #[test]
     fn error_stack_feature_compiles() {
@@ -68,7 +63,6 @@ mod error_stack_enabled {
 
 #[cfg(feature = "log")]
 mod log_enabled {
-    use super::*;
 
     #[test]
     fn log_feature_compiles() {
@@ -82,7 +76,6 @@ mod log_enabled {
 
 #[cfg(feature = "secure_log")]
 mod secure_log_enabled {
-    use super::*;
 
     #[test]
     fn secure_log_feature_compiles() {

--- a/tests/test_export.rs
+++ b/tests/test_export.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 mod events;
 
 #[cfg(test)]
-#[cfg_attr(test, allow(unused_imports, path_statements))]
+#[cfg_attr(test, allow(unused_imports, deprecated, path_statements))]
 #[test]
 fn api_export() {
     use nozomi::Error;


### PR DESCRIPTION
## Summary

- Complete documentation for the v3.1.0 API (`DeleteRequest`, `DeleteReport`, `DeleteEvent`, `analyze`, `dry-run`, `verify`)
- Tag legacy `SecureDelete` API as deprecated
- Add CI/CD pipeline: automated publish workflow (`publish.yml`) triggered on Dependabot merges, with manual approval gate, multi-branch support (`N.x`), changelog propagation, and conditional push to `main`
- Improve GitHub community health files: PR template, bug report template, feature request template

## Part of the release chain

`release/v3.1.0-prep` → **`3.1.0`** → `v3.x.x` → `main`