### PR TITLE
Release/v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
+## [v3.1.1](https://crates.io/crates/nozomi/3.1.1)
 
+```diff
+Bug fixes :
+- Fixes dispatch reversal bug between DOD 52022 MECE and DOD 52022 ME
+- Fixes bug where I forgot to sync_all after writes
+- Remove implicit dependancy to unix system
+```
 ## [v3.1.0](https://crates.io/crates/nozomi/3.1.0)
 
 ```diff

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nozomi"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 rust-version = "1.85"
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -75,10 +75,10 @@ later:
 
 ```toml
 # Before
-nozomi = { version = "3.1.0", features = ["error-stack"] }
+nozomi = { version = "3.1.1", features = ["error-stack"] }
 
 # After
-nozomi = { version = "3.1.0" }
+nozomi = { version = "3.1.1" }
 ```
 
 Adjust your error handling to use the standard `nozomi::Error` type directly.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Enable features in `Cargo.toml`:
 
 ```toml
 [dependencies]
-nozomi = { version = "3.1.0", features = ["verify", "dry-run"] }
+nozomi = { version = "3.1.1", features = ["verify", "dry-run"] }
 ```
 
 ---

--- a/src/engine/overwrite/afssi_5020.rs
+++ b/src/engine/overwrite/afssi_5020.rs
@@ -76,6 +76,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Afssi5020, pass as u32))?;
+        file.sync_all().map_err(|_| {
+            Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+        })?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -166,6 +169,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .change_context(Error::OverwriteError(Method::Afssi5020, pass as u32))?;
+        file.sync_all().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {

--- a/src/engine/overwrite/dod_522022_me.rs
+++ b/src/engine/overwrite/dod_522022_me.rs
@@ -75,6 +75,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Dod522022ME, pass as u32))?;
+        file.sync_all().map_err(|_| {
+            Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+        })?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -164,6 +167,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .change_context(Error::OverwriteError(Method::Dod522022ME, pass as u32))?;
+        file.sync_all().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {

--- a/src/engine/overwrite/dod_522022_mece.rs
+++ b/src/engine/overwrite/dod_522022_mece.rs
@@ -86,6 +86,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
         // flush after each pass (best-effort)
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::Dod522022MECE, pass as u32))?;
+        file.sync_all().map_err(|_| {
+            Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+        })?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -175,6 +178,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
         // flush after each pass (best-effort)
         file.flush()
             .change_context(Error::OverwriteError(Method::Dod522022MECE, pass as u32))?;
+        file.sync_all().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {

--- a/src/engine/overwrite/gutmann.rs
+++ b/src/engine/overwrite/gutmann.rs
@@ -100,6 +100,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
             file.write_all(&buffer[..write_size])
                 .map_err(|_| Error::OverwriteError(Method::Gutmann, pass as u32))?;
+            file.sync_all().map_err(|_| {
+                Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+            })?;
             remaining -= write_size as u64;
         }
 
@@ -197,6 +200,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
         }
 
         file.flush().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
+        file.sync_all().change_context(Error::SystemProblem(
             FSProblem::Write,
             format!("{}", path.to_string_lossy()),
         ))?;

--- a/src/engine/overwrite/hmgi_s5.rs
+++ b/src/engine/overwrite/hmgi_s5.rs
@@ -46,6 +46,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::HmgiS5, &pattern + 1))?;
+        file.sync_all().map_err(|_| {
+            Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+        })?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -113,6 +116,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
         file.flush()
             .change_context(Error::OverwriteError(Method::HmgiS5, &pattern + 1))?;
+        file.sync_all().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {

--- a/src/engine/overwrite/mod.rs
+++ b/src/engine/overwrite/mod.rs
@@ -40,8 +40,8 @@ pub(crate) fn overwrite_file<S: EventSink>(
     sink: &mut S,
 ) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path, sink)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Dod522022MECE => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_me::overwrite_file(path, sink)?,
         Method::Afssi5020 => afssi_5020::overwrite_file(path, sink)?,
         Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path, sink)?,
         Method::HmgiS5 => hmgi_s5::overwrite_file(path, sink)?,
@@ -67,8 +67,8 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(
     sink: &mut S,
 ) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::dry_overwrite_file(path, sink)?,
-        Method::Dod522022ME => dod_522022_mece::dry_overwrite_file(path, sink)?,
+        Method::Dod522022MECE => dod_522022_mece::dry_overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_me::dry_overwrite_file(path, sink)?,
         Method::Afssi5020 => afssi_5020::dry_overwrite_file(path, sink)?,
         Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::dry_overwrite_file(path, sink)?,
         Method::HmgiS5 => hmgi_s5::dry_overwrite_file(path, sink)?,
@@ -95,8 +95,8 @@ pub(crate) fn overwrite_file<S: EventSink>(
     sink: &mut S,
 ) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::overwrite_file(path, sink)?,
-        Method::Dod522022ME => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Dod522022MECE => dod_522022_mece::overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_me::overwrite_file(path, sink)?,
         Method::Afssi5020 => afssi_5020::overwrite_file(path, sink)?,
         Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::overwrite_file(path, sink)?,
         Method::HmgiS5 => hmgi_s5::overwrite_file(path, sink)?,
@@ -122,8 +122,8 @@ pub(crate) fn dry_overwrite_file<S: EventSink>(
     sink: &mut S,
 ) -> Result<()> {
     match method {
-        Method::Dod522022MECE => dod_522022_me::dry_overwrite_file(path, sink)?,
-        Method::Dod522022ME => dod_522022_mece::dry_overwrite_file(path, sink)?,
+        Method::Dod522022MECE => dod_522022_mece::dry_overwrite_file(path, sink)?,
+        Method::Dod522022ME => dod_522022_me::dry_overwrite_file(path, sink)?,
         Method::Afssi5020 => afssi_5020::dry_overwrite_file(path, sink)?,
         Method::RcmpTssitOpsII => rcmp_tssit_ops_ii::dry_overwrite_file(path, sink)?,
         Method::HmgiS5 => hmgi_s5::dry_overwrite_file(path, sink)?,

--- a/src/engine/overwrite/rcmp_tssit_ops_ii.rs
+++ b/src/engine/overwrite/rcmp_tssit_ops_ii.rs
@@ -53,6 +53,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
         // flush after each pass (best-effort)
         file.flush()
             .map_err(|_| Error::OverwriteError(Method::RcmpTssitOpsII, &pattern + 1))?;
+        file.sync_all().map_err(|_| {
+            Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+        })?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {
@@ -79,6 +82,9 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
 
     file.flush()
         .map_err(|_| Error::OverwriteError(Method::RcmpTssitOpsII, 7))?;
+    file.sync_all().map_err(|_| {
+        Error::SystemProblem(FSProblem::Write, format!("{}", path.to_string_lossy()))
+    })?;
     emit_safe(
         sink,
         DeleteEvent::EntryOverwritePass {
@@ -151,6 +157,10 @@ pub(crate) fn overwrite_file<S: EventSink>(path: &Path, sink: &mut S) -> Result<
         // flush after each pass (best-effort)
         file.flush()
             .change_context(Error::OverwriteError(Method::RcmpTssitOpsII, &pattern + 1))?;
+        file.sync_all().change_context(Error::SystemProblem(
+            FSProblem::Write,
+            format!("{}", path.to_string_lossy()),
+        ))?;
         emit_safe(
             sink,
             DeleteEvent::EntryOverwritePass {

--- a/src/models.rs
+++ b/src/models.rs
@@ -19,7 +19,6 @@ use crate::{PassInfo, PassKind};
 use std::{
     fs::{self, OpenOptions},
     io::{BufWriter, Write},
-    os::unix::fs::MetadataExt,
     path::Path,
 };
 
@@ -328,7 +327,7 @@ impl SecureDelete {
         let file_size = file_to_overwrite
             .metadata()
             .map_err(|_| Error::SystemProblem(FSProblem::Opening, self.path.clone()))?
-            .size();
+            .len();
         let mut overwrite_length: u64 = 0;
         let mut overwriting_buffer = BufWriter::new(file_to_overwrite);
 
@@ -753,7 +752,7 @@ impl SecureDelete {
         let file_size = file_to_overwrite
             .metadata()
             .change_context(Error::SystemProblem(FSProblem::Opening, self.path.clone()))?
-            .size();
+            .len();
         let mut overwrite_length: u64 = 0;
         let mut overwriting_buffer = BufWriter::new(file_to_overwrite);
 


### PR DESCRIPTION
# Pull Request

---

## 🏷️ Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Dependency update

---

## 📝 Description

Fixes for a few bugs discovered after the release of version 3.1.0

### Changes

- Fixes dispatch reversal bug between DOD 52022 MECE and DOD 52022 ME
- Fixes bug where I forgot to sync_all after writes
- Remove implicit dependancy to unix system

---

## 🔒 Security Considerations

Secure deletion is a sensitive operation. Confirm:

- [x] No data loss risk introduced
- [x] No panic on user input
- [x] File operations remain deterministic

---

## 🚀 API Impact

- [x] No API change
- [x] Backward compatible change
- [x] Breaking change — migration notes below


## ⚙️ Components affected

- [ ] API / Builder
- [x] Engine (Planner / Executor)
- [x] Overwrite algorithms
- [ ] Events / Report
- [ ] Error handling
- [ ] CI / Tooling

---

## 🧪 Testing

- [ ] Unit tests added / updated
- [ ] Integration tests updated
- [ ] Edge cases covered
- [x] All existing tests pass (`cargo test`)

## ✅ Checklist

- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] Public API documented
- [x] CHANGELOG / MIGRATION.md updated if needed
